### PR TITLE
add nitros image and cam-info publishers

### DIFF
--- a/zed_components/CMakeLists.txt
+++ b/zed_components/CMakeLists.txt
@@ -112,7 +112,7 @@ set(DEPENDENCIES
     isaac_ros_nitros
     isaac_ros_managed_nitros
     isaac_ros_nitros_image_type
-    isaac_ros_common
+    isaac_ros_nitros_camera_info_type
 )
 
 find_package(ament_cmake_auto REQUIRED)
@@ -144,7 +144,7 @@ find_package(robot_localization REQUIRED)
 find_package(isaac_ros_nitros REQUIRED)
 find_package(isaac_ros_managed_nitros REQUIRED)
 find_package(isaac_ros_nitros_image_type REQUIRED)
-find_package(isaac_ros_common REQUIRED)
+find_package(isaac_ros_nitros_camera_info_type REQUIRED)
 
 if(NOT ${FOUND_ROS2_DISTRO} STREQUAL "foxy")
   find_package(point_cloud_transport REQUIRED)
@@ -212,6 +212,16 @@ set(ZED_CAMERA_ONE_INC
 set(ZED_CAMERA_ONE_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/src/zed_camera/src/zed_camera_one_component.cpp
 )
+
+set(ZED_CAMERA_NITROS_INC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/include/visibility_control.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/zed_camera/include/sl_types.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/zed_camera/include/zed_camera_nitros_component.hpp
+)
+
+set(ZED_CAMERA_NITROS_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/zed_camera/src/zed_camera_nitros_component.cpp
+)
 ###############################################################################
 # Bin and Install
 
@@ -228,6 +238,13 @@ target_include_directories(zed_camera_component PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/src/include
     ${CMAKE_CURRENT_SOURCE_DIR}/src/zed_camera/include
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/include
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>  
+    $<INSTALL_INTERFACE:include>
+)
+set_target_properties(zed_camera_component PROPERTIES
+  BUILD_WITH_INSTALL_RPATH TRUE
+  BUILD_RPATH_USE_ORIGIN TRUE
+  INSTALL_RPATH_USE_LINK_PATH TRUE
 )
 target_compile_definitions(zed_camera_component
     PRIVATE "COMPOSITION_BUILDING_DLL"
@@ -241,6 +258,40 @@ ament_target_dependencies(zed_camera_component
 
 rclcpp_components_register_nodes(zed_camera_component "stereolabs::ZedCamera")
 set(node_plugins "${node_plugins}stereolabs::ZedCamera;$<TARGET_FILE:zed_camera_component>\n")
+
+# ZED Camera Nitros Component
+add_library(zed_camera_nitros_component SHARED
+    ${SL_TOOLS_INC}
+    ${SL_TOOLS_SRC}
+    ${ZED_CAMERA_NITROS_INC}
+    ${ZED_CAMERA_NITROS_SRC}
+)
+target_include_directories(zed_camera_nitros_component PUBLIC
+    ${CUDA_INCLUDE_DIRS}
+    ${ZED_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/zed_camera/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/include
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>  
+    $<INSTALL_INTERFACE:include>
+)
+set_target_properties(zed_camera_nitros_component PROPERTIES
+  BUILD_WITH_INSTALL_RPATH TRUE
+  BUILD_RPATH_USE_ORIGIN TRUE
+  INSTALL_RPATH_USE_LINK_PATH TRUE
+)
+target_compile_definitions(zed_camera_nitros_component
+    PRIVATE "COMPOSITION_BUILDING_DLL"
+)
+target_link_libraries(zed_camera_nitros_component
+    ${ZED_LIBS}
+)
+ament_target_dependencies(zed_camera_nitros_component
+    ${DEPENDENCIES}
+)
+
+rclcpp_components_register_nodes(zed_camera_nitros_component "stereolabs::ZedCameraNitros")
+set(node_plugins "${node_plugins}stereolabs::ZedCameraNitros;$<TARGET_FILE:zed_camera_nitros_component>\n")
 
 # ZED Camera One Component
 add_library(zed_camera_one_component SHARED
@@ -270,7 +321,7 @@ rclcpp_components_register_nodes(zed_camera_one_component "stereolabs::ZedCamera
 set(node_plugins "${node_plugins}stereolabs::ZedCameraOne;$<TARGET_FILE:zed_camera_one_component>\n")
 
 # Install components
-install(TARGETS zed_camera_component zed_camera_one_component
+install(TARGETS zed_camera_component zed_camera_one_component zed_camera_nitros_component
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}
@@ -288,6 +339,7 @@ ament_export_include_directories(include)
 ament_export_libraries(
     zed_camera_component
     zed_camera_one_component
+    zed_camera_nitros_component
 )
 ament_export_dependencies(${DEPENDENCIES})
-ament_package()
+ament_auto_package()

--- a/zed_components/CMakeLists.txt
+++ b/zed_components/CMakeLists.txt
@@ -109,6 +109,10 @@ set(DEPENDENCIES
     visualization_msgs
     shape_msgs
     robot_localization
+    isaac_ros_nitros
+    isaac_ros_managed_nitros
+    isaac_ros_nitros_image_type
+    isaac_ros_common
 )
 
 find_package(ament_cmake_auto REQUIRED)
@@ -137,6 +141,10 @@ find_package(diagnostic_updater REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(shape_msgs REQUIRED)
 find_package(robot_localization REQUIRED)
+find_package(isaac_ros_nitros REQUIRED)
+find_package(isaac_ros_managed_nitros REQUIRED)
+find_package(isaac_ros_nitros_image_type REQUIRED)
+find_package(isaac_ros_common REQUIRED)
 
 if(NOT ${FOUND_ROS2_DISTRO} STREQUAL "foxy")
   find_package(point_cloud_transport REQUIRED)

--- a/zed_components/package.xml
+++ b/zed_components/package.xml
@@ -62,6 +62,10 @@
     <exec_depend>draco_point_cloud_transport</exec_depend>
     <exec_depend>zlib_point_cloud_transport</exec_depend>
     <exec_depend>zstd_point_cloud_transport</exec_depend>
+    <exec_depend>isaac_ros_nitros</exec_depend>
+    <exec_depend>isaac_ros_managed_nitros</exec_depend>
+    <exec_depend>isaac_ros_nitros_image_type</exec_depend>
+    <exec_depend>isaac_ros_nitros_camera_info_type</exec_depend>
     <test_depend>ament_lint_auto</test_depend>
     <test_depend>ament_cmake_copyright</test_depend>
     <test_depend>ament_cmake_cppcheck</test_depend>

--- a/zed_components/src/tools/include/sl_tools.hpp
+++ b/zed_components/src/tools/include/sl_tools.hpp
@@ -25,6 +25,7 @@
 #include <isaac_ros_nitros_image_type/nitros_image.hpp>
 #include <isaac_ros_nitros_image_type/nitros_image_builder.hpp>
 #include <isaac_ros_nitros_camera_info_type/nitros_camera_info.hpp>
+#include <cuda_runtime.h>
 #include <std_msgs/msg/header.hpp>
 #include <sensor_msgs/image_encodings.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>

--- a/zed_components/src/tools/include/sl_tools.hpp
+++ b/zed_components/src/tools/include/sl_tools.hpp
@@ -22,6 +22,12 @@
 #include <sl/Camera.hpp>
 #include <string>
 #include <vector>
+#include <isaac_ros_nitros_image_type/nitros_image.hpp>
+#include <isaac_ros_nitros_image_type/nitros_image_builder.hpp>
+#include <isaac_ros_nitros_camera_info_type/nitros_camera_info.hpp>
+#include <std_msgs/msg/header.hpp>
+#include <sensor_msgs/image_encodings.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
 
 #include "gnss_replay.hpp"
 #include "sl_win_avg.hpp"
@@ -90,6 +96,12 @@ std::unique_ptr<sensor_msgs::msg::Image> imageToROSmsg(
 std::unique_ptr<sensor_msgs::msg::Image> imagesToROSmsg(
   const sl::Mat & left, const sl::Mat & right, const std::string & frameId,
   const rclcpp::Time & t);
+
+nvidia::isaac_ros::nitros::NitrosImage imageToNitrosImage(
+  const sl::Mat & img, const std::string & frameId, const rclcpp::Time & t);
+
+nvidia::isaac_ros::nitros::NitrosCameraInfo cameraInfoToNitrosCameraInfo(
+  const std::shared_ptr<sensor_msgs::msg::CameraInfo> & camInfo, const std::string & frameId, const rclcpp::Time & t);
 
 /*! \brief qos value to string
  * \param qos the value to convert

--- a/zed_components/src/zed_camera/include/sl_types.hpp
+++ b/zed_components/src/zed_camera/include/sl_types.hpp
@@ -61,6 +61,7 @@
 #include <zed_msgs/srv/start_svo_rec.hpp>
 #include <isaac_ros_managed_nitros/managed_nitros_publisher.hpp>
 #include <isaac_ros_nitros_image_type/nitros_image.hpp>
+#include <isaac_ros_nitros_image_type/nitros_image_builder.hpp>
 #include <isaac_ros_nitros_camera_info_type/nitros_camera_info.hpp>
 #include <isaac_ros_common/qos.hpp>
 

--- a/zed_components/src/zed_camera/include/sl_types.hpp
+++ b/zed_components/src/zed_camera/include/sl_types.hpp
@@ -59,6 +59,10 @@
 #include <zed_msgs/srv/set_pose.hpp>
 #include <zed_msgs/srv/set_roi.hpp>
 #include <zed_msgs/srv/start_svo_rec.hpp>
+#include <isaac_ros_managed_nitros/managed_nitros_publisher.hpp>
+#include <isaac_ros_nitros_image_type/nitros_image.hpp>
+#include <isaac_ros_nitros_camera_info_type/nitros_camera_info.hpp>
+#include <isaac_ros_common/qos.hpp>
 
 #ifndef FOUND_FOXY
   #include <point_cloud_transport/point_cloud_transport.hpp>

--- a/zed_components/src/zed_camera/include/zed_camera_component.hpp
+++ b/zed_components/src/zed_camera/include/zed_camera_component.hpp
@@ -27,6 +27,10 @@
 namespace stereolabs
 {
 
+namespace {
+    constexpr const char kDefaultQoS[] = "DEFAULT";
+}
+
 class ZedCamera : public rclcpp::Node
 {
 public:
@@ -163,6 +167,12 @@ protected:
   void publishImageWithInfo(
     sl::Mat & img,
     image_transport::CameraPublisher & pubImg,
+    camInfoMsgPtr & camInfoMsg, std::string imgFrameId,
+    rclcpp::Time t);
+  void publishNitrosImageWithInfo(
+    sl::Mat & img,
+    std::shared_ptr<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosImage>> & pubImg,
+    std::shared_ptr<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosCameraInfo>> & pubNitrosCamInfo,
     camInfoMsgPtr & camInfoMsg, std::string imgFrameId,
     rclcpp::Time t);
   void publishDepthMapWithInfo(sl::Mat & depth, rclcpp::Time t);
@@ -586,6 +596,14 @@ private:
   image_transport::CameraPublisher mPubRawRightGray;
 
   image_transport::CameraPublisher mPubRoiMask;
+
+  // ---- Nitros Image Publishers
+  std::shared_ptr<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosImage>> mNitrosPubRightRgb;
+  std::shared_ptr<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosImage>> mNitrosPubLeftRgb;
+  std::shared_ptr<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosCameraInfo>> mNitrosPubRightRgbInfo;
+  std::shared_ptr<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosCameraInfo>> mNitrosPubLeftRgbInfo;
+  const rclcpp::QoS output_qos_nitros = ::isaac_ros::common::AddQosParameter(
+    *this, kDefaultQoS, "output_qos").keep_last(10);
 
 #ifndef FOUND_FOXY
   point_cloud_transport::Publisher mPubCloud;

--- a/zed_components/src/zed_camera/include/zed_camera_nitros_component.hpp
+++ b/zed_components/src/zed_camera/include/zed_camera_nitros_component.hpp
@@ -1,0 +1,296 @@
+#ifndef ZED_CAMERA_NITROS_COMPONENT_HPP_
+#define ZED_CAMERA_NITROS_COMPONENT_HPP_
+
+#include <atomic>
+#include <sl/Camera.hpp>
+#include <sl/Fusion.hpp>
+#include <unordered_set>
+
+#include "sl_tools.hpp"
+#include "sl_types.hpp"
+#include "visibility_control.hpp"
+
+namespace stereolabs
+{
+
+namespace {
+    constexpr const char kDefaultQoS[] = "DEFAULT";
+}
+
+class ZedCameraNitros : public rclcpp::Node
+{
+public:
+  ZED_COMPONENTS_PUBLIC
+  explicit ZedCameraNitros(const rclcpp::NodeOptions & options);
+  ~ZedCameraNitros();
+
+protected:
+  void init();
+  void initParameters();
+  void initServices();
+  void initThreads();
+
+  // -----> Get Parameters functions
+  void getGeneralParams();
+  void getVideoParams();
+  void getSensorsParams();
+  void getAdvancedParams();
+  void getDebugParams();
+
+  // <----- Get Parameters functions
+  // ----> Thread functions
+  void threadFunc_zedGrab();
+  void threadFunc_pointcloudElab();
+  void threadFunc_pubSensorsData();
+  // <---- Thread functions
+
+  bool startCamera();
+  void retrieveVideoDepth();
+  void publishVideoDepth(rclcpp::Time & out_pub_ts);
+  void applyVideoSettings();
+
+  // ----> Callbacks
+  rcl_interfaces::msg::SetParametersResult callback_setParameters(
+    std::vector<rclcpp::Parameter> parameters);
+  void callback_updateDiagnostic(
+    diagnostic_updater::DiagnosticStatusWrapper & stat);
+  void callback_pubTemp();
+  // <---- Callbacks
+
+  void setTFCoordFrameNames();
+  void initPublishers();
+  void initSubscribers();
+  void fillCamInfo(
+    const std::shared_ptr<sl::Camera> zed,
+    const std::shared_ptr<sensor_msgs::msg::CameraInfo> & leftCamInfoMsg,
+    const std::shared_ptr<sensor_msgs::msg::CameraInfo> & rightCamInfoMsg,
+    const std::string & leftFrameId, const std::string & rightFrameId,
+    bool rawParam = false);
+
+  void publishNitrosImageWithInfo(
+    sl::Mat & img,
+    std::shared_ptr<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosImage>> & pubImg,
+    std::shared_ptr<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosCameraInfo>> & pubNitrosCamInfo,
+    camInfoMsgPtr & camInfoMsg, std::string imgFrameId,
+    rclcpp::Time t);
+  
+  void startTempPubTimer();
+
+  template<typename T>
+  void getParam(
+    std::string paramName, T defValue, T & outVal,
+    std::string log_info = std::string(), bool dynamic = false);
+
+private:
+  // ZED SDK
+  std::shared_ptr<sl::Camera> mZed;
+  sl::InitParameters mInitParams;
+  sl::RuntimeParameters mRunParams;
+
+  uint64_t mFrameCount = 0;
+
+  std::string mTopicRoot = "~/";
+
+    // ----> Thread Sync
+  std::mutex mRecMutex;
+  std::mutex mDynParMutex;
+  std::mutex mPcMutex;
+  std::condition_variable mPcDataReadyCondVar;
+  std::atomic_bool mPcDataReady;
+  // <---- Thread Sync
+
+  // ----> Timestamps
+  sl::Timestamp mLastTs_grab = 0;  // Used to calculate stable publish frequency
+  rclcpp::Time mFrameTimestamp;
+  rclcpp::Time mLastTs_pc;
+  rclcpp::Time mPrevTs_pc;
+  rclcpp::Time mLastClock;
+  // <---- Timestamps
+
+  sl::MODEL mCamUserModel = sl::MODEL::ZED;  // Default camera model
+  sl::MODEL mCamRealModel;                   // Camera model requested to SDK
+  unsigned int mCamFwVersion;                // Camera FW version
+  unsigned int mSensFwVersion;               // Sensors FW version
+  std::string mCameraName = "zed";           // Default camera name
+  std::string mSvoFilepath = "";
+  int mCamGrabFrameRate = 15;
+  int mVerbose = 1;
+  int mGpuId = -1;
+  std::string mOpencvCalibFile;
+  sl::RESOLUTION mCamResol =
+    sl::RESOLUTION::HD1080;    // Default resolution: RESOLUTION_HD1080
+  PubRes mPubResolution =
+    PubRes::NATIVE;                     // Use native grab resolution by default
+  double mCustomDownscaleFactor = 1.0;  // Used to rescale data with user factor
+
+  // ----> Status Flags
+  bool mSvoMode = false;
+  bool mTriggerAutoExpGain = true;  // Triggered on start
+  bool mTriggerAutoWB = true;       // Triggered on start
+  // <---- Status Flags
+
+  // -----------> Dynamic parameters handling
+  OnSetParametersCallbackHandle::SharedPtr mParamChangeCallbackHandle;
+
+  double mPubFrameRate = 15.0;
+  int mCamBrightness = 4;
+  int mCamContrast = 4;
+  int mCamHue = 0;
+  int mCamSaturation = 4;
+  int mCamSharpness = 4;
+  int mCamGamma = 8;
+  bool mCamAutoExpGain = true;
+  int mCamGain = 80;
+  int mCamExposure = 80;
+  bool mCamAutoWB = true;
+  int mCamWBTemp = 42;
+  int mDepthConf = 50;
+  int mDepthTextConf = 100;
+  double mPcPubRate = 15.0;
+  double mFusedPcPubRate = 1.0;
+  bool mRemoveSatAreas = true;
+
+  int mGmslExpTime = 16666;
+  int mGmslAutoExpTimeRangeMin = 28;
+  int mGmslAutoExpTimeRangeMax = 30000;
+  int mGmslExposureComp = 50;
+  int mGmslAnalogGain = 8000;
+  int mGmslAnalogGainRangeMin = 1000;
+  int mGmslAnalogGainRangeMax = 16000;
+  int mGmslDigitalGain = 128;
+  int mGmslAutoDigitalGainRangeMin = 1;
+  int mGmslAutoDigitalGainRangeMax = 256;
+  int mGmslDenoising = 50;
+  // <----------- Dynamic parameters handling
+
+    // ----> QoS
+  // https://github.com/ros2/ros2/wiki/About-Quality-of-Service-Settings
+  rclcpp::QoS mQos;
+  rclcpp::PublisherOptions mPubOpt;
+  rclcpp::SubscriptionOptions mSubOpt;
+  // <---- QoS
+
+  // ----> Frame IDs
+  std::string mRgbFrameId;
+  std::string mRgbOptFrameId;
+  std::string mCameraFrameId;
+  std::string mRightCamFrameId;
+  std::string mRightCamOptFrameId;
+  std::string mLeftCamFrameId;
+  std::string mLeftCamOptFrameId;
+  std::string mTempLeftFrameId;
+  std::string mTempRightFrameId;
+  // <---- Frame IDs
+
+    // ----> Stereolabs Mat Info
+  int mCamWidth;   // Camera frame width
+  int mCamHeight;  // Camera frame height
+  sl::Resolution mMatResol;
+  // <---- Stereolabs Mat Info
+
+    // ---- Nitros Image Publishers
+  rclcpp::Time publishSensorsData(rclcpp::Time t = TIMEZERO_ROS);
+  std::shared_ptr<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosImage>> mNitrosPubRightRgb;
+  std::shared_ptr<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosImage>> mNitrosPubLeftRgb;
+  std::shared_ptr<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosCameraInfo>> mNitrosPubRightRgbInfo;
+  std::shared_ptr<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosCameraInfo>> mNitrosPubLeftRgbInfo;
+  const rclcpp::QoS output_qos_nitros = ::isaac_ros::common::AddQosParameter(
+    *this, kDefaultQoS, "output_qos").keep_last(10);
+  // <---- Nitros Image Publishers
+
+  // ----> Threads and Timers
+  sl::ERROR_CODE mGrabStatus;
+  sl::ERROR_CODE mConnStatus;
+  sl::FUSION_ERROR_CODE mFusionStatus = sl::FUSION_ERROR_CODE::MODULE_NOT_ENABLED;
+  std::thread mGrabThread;        // Main grab thread
+  std::thread mPcThread;          // Point Cloud publish thread
+  std::thread mSensThread;        // Sensors data publish thread
+  std::atomic<bool> mThreadStop;
+  rclcpp::TimerBase::SharedPtr mInitTimer;
+  rclcpp::TimerBase::SharedPtr mPathTimer;
+  rclcpp::TimerBase::SharedPtr mFusedPcTimer;
+  rclcpp::TimerBase::SharedPtr mTempPubTimer;    // Timer to retrieve and publish CMOS temperatures
+  rclcpp::TimerBase::SharedPtr mGnssPubCheckTimer;
+  // <---- Threads and Timers
+
+  // -----> Parameter Variables
+  bool mDebugMode = false;  // Debug mode active?
+  bool _debugCommon = false;
+  bool _debugSensors = false;
+  bool _debugCamCtrl = false;
+  bool _debugAdvanced = false;
+  bool _debugVideoDepth = false;
+  int mCamSerialNumber = 0;
+  int mCamTimeoutSec = 5;
+  int mMaxReconnectTemp = 5;
+  bool mCameraSelfCalib = true;
+  bool mCameraFlip = false;
+  bool mPublishImuTF = false;
+  bool mSensCameraSync = false;
+  double mSensPubRate = 400.;
+
+  std::string mThreadSchedPolicy;
+  int mThreadPrioGrab;
+  int mThreadPrioSens;
+  // <----- Parameter Variables
+
+  // <----- Diagnostic
+  float mTempImu = NOT_VALID_TEMP;
+  float mTempLeft = NOT_VALID_TEMP;
+  float mTempRight = NOT_VALID_TEMP;
+  diagnostic_updater::Updater mDiagUpdater;  // Diagnostic Updater
+  std::unique_ptr<sl_tools::WinAvg> mGrabPeriodMean_sec;
+  std::unique_ptr<sl_tools::WinAvg> mElabPeriodMean_sec;
+  int mSysOverloadCount = 0;
+    sl_tools::StopWatch mGrabFreqTimer;
+  // -----> Diagnostic
+
+  // Camera IMU transform
+  sl::Transform mSlCamImuTransf;
+
+  // ----> initialization Transform listener
+  std::unique_ptr<tf2_ros::Buffer> mTfBuffer;
+  std::unique_ptr<tf2_ros::TransformListener> mTfListener;
+  std::unique_ptr<tf2_ros::TransformBroadcaster> mTfBroadcaster;
+  // <---- initialization Transform listener
+
+  // ----> Messages (ONLY THOSE NOT CHANGING WHILE NODE RUNS)
+  // Camera infos
+  camInfoMsgPtr mRgbCamInfoMsg;
+  camInfoMsgPtr mLeftCamInfoMsg;
+  camInfoMsgPtr mRightCamInfoMsg;
+  camInfoMsgPtr mRgbCamInfoRawMsg;
+  camInfoMsgPtr mLeftCamInfoRawMsg;
+  camInfoMsgPtr mRightCamInfoRawMsg;
+  camInfoMsgPtr mDepthCamInfoMsg;
+  // <---- Messages
+};
+
+// ----> Template Function definitions
+template<typename T>
+void ZedCameraNitros::getParam(
+  std::string paramName, T defValue, T & outVal,
+  std::string log_info, bool dynamic)
+{
+  rcl_interfaces::msg::ParameterDescriptor descriptor;
+  descriptor.read_only = !dynamic;
+
+  declare_parameter(paramName, rclcpp::ParameterValue(defValue), descriptor);
+
+  if (!get_parameter(paramName, outVal)) {
+    RCLCPP_WARN_STREAM(
+      get_logger(),
+      "The parameter '"
+        << paramName
+        << "' is not available or is not valid, using the default value: "
+        << defValue);
+  }
+
+  if (!log_info.empty()) {
+    RCLCPP_INFO_STREAM(get_logger(), log_info << outVal);
+  }
+}
+
+} // namespace stereolabs
+
+#endif  // ZED_CAMERA_NITROS_COMPONENT_HPP_

--- a/zed_components/src/zed_camera/src/zed_camera_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_component.cpp
@@ -3517,52 +3517,52 @@ void ZedCamera::initPublishers()
     get_logger(), "Advertised on topic: " << mPubRawRightGray.getInfoTopic());
 
   // Nitros Image topics
-  mNitrosPubLeftRgb = std::make_shared<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosImage>>(
-    this,
-    nitros_rbg_left_topic,
-    nvidia::isaac_ros::nitros::nitros_image_bgra8_t::supported_type_name,
-    nvidia::isaac_ros::nitros::NitrosDiagnosticsConfig(),
-    output_qos_nitros
-  );
+  // mNitrosPubLeftRgb = std::make_shared<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosImage>>(
+  //   this,
+  //   nitros_rbg_left_topic,
+  //   nvidia::isaac_ros::nitros::nitros_image_bgra8_t::supported_type_name,
+  //   nvidia::isaac_ros::nitros::NitrosDiagnosticsConfig(),
+  //   output_qos_nitros
+  // );
 
   RCLCPP_INFO_STREAM(
     get_logger(),
     "Advertised Nitros on toipc: " << nitros_rbg_left_topic
   );
 
-  mNitrosPubRightRgb = std::make_shared<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosImage>>(
-    this,
-    nitros_rbg_right_topic,
-    nvidia::isaac_ros::nitros::nitros_image_bgra8_t::supported_type_name,
-    nvidia::isaac_ros::nitros::NitrosDiagnosticsConfig(),
-    output_qos_nitros
-  );
+  // mNitrosPubRightRgb = std::make_shared<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosImage>>(
+  //   this,
+  //   nitros_rbg_right_topic,
+  //   nvidia::isaac_ros::nitros::nitros_image_bgra8_t::supported_type_name,
+  //   nvidia::isaac_ros::nitros::NitrosDiagnosticsConfig(),
+  //   output_qos_nitros
+  // );
 
   RCLCPP_INFO_STREAM(
     get_logger(),
     "Advertised Nitros on toipc: " << nitros_rbg_right_topic
   );
 
-  mNitrosPubRightRgbInfo = std::make_shared<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosCameraInfo>>(
-    this,
-    nitros_rbg_right_topic_info,
-    nvidia::isaac_ros::nitros::nitros_camera_info_t::supported_type_name,
-    nvidia::isaac_ros::nitros::NitrosDiagnosticsConfig(),
-    output_qos_nitros
-  );
+  // mNitrosPubRightRgbInfo = std::make_shared<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosCameraInfo>>(
+  //   this,
+  //   nitros_rbg_right_topic_info,
+  //   nvidia::isaac_ros::nitros::nitros_camera_info_t::supported_type_name,
+  //   nvidia::isaac_ros::nitros::NitrosDiagnosticsConfig(),
+  //   output_qos_nitros
+  // );
 
   RCLCPP_INFO_STREAM(
     get_logger(),
     "Advertised Nitros on toipc: " << nitros_rbg_right_topic_info
   );
 
-  mNitrosPubLeftRgbInfo = std::make_shared<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosCameraInfo>>(
-    this,
-    nitros_rbg_left_topic_info,
-    nvidia::isaac_ros::nitros::nitros_camera_info_t::supported_type_name,
-    nvidia::isaac_ros::nitros::NitrosDiagnosticsConfig(),
-    output_qos_nitros
-  );
+  // mNitrosPubLeftRgbInfo = std::make_shared<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosCameraInfo>>(
+  //   this,
+  //   nitros_rbg_left_topic_info,
+  //   nvidia::isaac_ros::nitros::nitros_camera_info_t::supported_type_name,
+  //   nvidia::isaac_ros::nitros::NitrosDiagnosticsConfig(),
+  //   output_qos_nitros
+  // );
 
   RCLCPP_INFO_STREAM(
     get_logger(),
@@ -4728,7 +4728,7 @@ bool ZedCamera::startCamera()
 void ZedCamera::initThreads()
 {
   // ----> Start CMOS Temperatures thread
-  if (!mSimMode && !sl_tools::isZED(mCamRealModel) &&
+  if (!sl_tools::isZED(mCamRealModel) &&
     !sl_tools::isZEDM(mCamRealModel))
   {
     startTempPubTimer();
@@ -7262,23 +7262,23 @@ void ZedCamera::publishVideoDepth(rclcpp::Time & out_pub_ts)
   out_pub_ts = timeStamp;
 
   // ----> Publish Right and Left Nitros images with info
-  publishNitrosImageWithInfo(
-    mMatLeft, 
-    mNitrosPubLeftRgb, 
-    mNitrosPubLeftRgbInfo,
-    mLeftCamInfoMsg,
-    mLeftCamOptFrameId,
-    out_pub_ts
-  );
+  // publishNitrosImageWithInfo(
+  //   mMatLeft, 
+  //   mNitrosPubLeftRgb, 
+  //   mNitrosPubLeftRgbInfo,
+  //   mLeftCamInfoMsg,
+  //   mLeftCamOptFrameId,
+  //   out_pub_ts
+  // );
 
-  publishNitrosImageWithInfo(
-    mMatRight, 
-    mNitrosPubRightRgb, 
-    mNitrosPubRightRgbInfo,
-    mRightCamInfoMsg,
-    mRightCamOptFrameId, 
-    out_pub_ts
-  );
+  // publishNitrosImageWithInfo(
+  //   mMatRight, 
+  //   mNitrosPubRightRgb, 
+  //   mNitrosPubRightRgbInfo,
+  //   mRightCamInfoMsg,
+  //   mRightCamOptFrameId, 
+  //   out_pub_ts
+  // );
 
   // ----> Publish the left=rgb image if someone has subscribed to
   if (mLeftSubCount > 0) {
@@ -7335,7 +7335,7 @@ void ZedCamera::publishVideoDepth(rclcpp::Time & out_pub_ts)
       mLeftCamOptFrameId, out_pub_ts);
   }
   if (mRgbGrayRawSubCount > 0) {
-    DEBUG_STREAM_VD("mRgbGrayRawSubCount: " << mRgbGrayRawSubCount);
+    DEBUG_STREAM_VD("mRgbGrayRawSubCount"  << mRgbGrayRawSubCount);
     publishImageWithInfo(
       mMatLeftRawGray, mPubRawRgbGray, mRgbCamInfoRawMsg,
       mDepthOptFrameId, out_pub_ts);

--- a/zed_components/src/zed_camera/src/zed_camera_nitros_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_nitros_component.cpp
@@ -1,0 +1,1969 @@
+#include "zed_camera_nitros_component.hpp"
+
+#include <sys/resource.h>
+
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+#include <limits>
+#include <rcl_interfaces/msg/parameter_descriptor.hpp>
+#include <rclcpp/time.hpp>
+#include <rclcpp/utilities.hpp>
+#include <sensor_msgs/distortion_models.hpp>
+#include <sensor_msgs/image_encodings.hpp>
+#include <sensor_msgs/msg/point_field.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <sstream>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+#include <sstream>
+
+#include "sl_logging.hpp"
+
+#ifdef FOUND_HUMBLE
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#elif defined FOUND_IRON
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#elif defined FOUND_FOXY
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#error Unsupported ROS2 distro
+#endif
+
+#include <sl/Camera.hpp>
+
+#include "sl_tools.hpp"
+
+using namespace std::chrono_literals;
+using namespace std::placeholders;
+
+namespace stereolabs
+{
+
+ZedCameraNitros::ZedCameraNitros(const rclcpp::NodeOptions & options)
+: Node("zed_camera_nitros", options),
+  mQos(QOS_QUEUE_SIZE),
+  mDiagUpdater(this),
+  mGrabFreqTimer(get_clock())
+{
+  RCLCPP_INFO(get_logger(), "********************************");
+  RCLCPP_INFO(get_logger(), "      ZED Camera Component ");
+  RCLCPP_INFO(get_logger(), "********************************");
+  RCLCPP_INFO(get_logger(), " * namespace: %s", get_namespace());
+  RCLCPP_INFO(get_logger(), " * node name: %s", get_name());
+  RCLCPP_INFO(get_logger(), "********************************");
+
+  const size_t SDK_MAJOR_REQ = 4;
+  const size_t SDK_MINOR_REQ = 2;
+
+  if (ZED_SDK_MAJOR_VERSION < SDK_MAJOR_REQ ||
+    (ZED_SDK_MAJOR_VERSION == SDK_MAJOR_REQ &&
+    ZED_SDK_MINOR_VERSION < SDK_MINOR_REQ))
+  {
+    RCLCPP_ERROR_STREAM(
+      get_logger(),
+      "This version of the ZED ROS2 wrapper is designed to work with ZED SDK "
+      "v" << static_cast<int>(SDK_MAJOR_REQ)
+          << "." << static_cast<int>(SDK_MINOR_REQ) << " or newer.");
+    RCLCPP_INFO_STREAM(
+      get_logger(), "* Detected SDK v"
+        << ZED_SDK_MAJOR_VERSION << "."
+        << ZED_SDK_MINOR_VERSION << "."
+        << ZED_SDK_PATCH_VERSION << "-"
+        << ZED_SDK_BUILD_ID);
+    RCLCPP_INFO(get_logger(), "Node stopped");
+    exit(EXIT_FAILURE);
+  }
+  
+  // ----> Start a "one shot timer" to initialize the node and make `shared_from_this` available
+  std::chrono::milliseconds init_msec(static_cast<int>(50.0));
+  mInitTimer = create_wall_timer(
+    std::chrono::duration_cast<std::chrono::milliseconds>(init_msec),
+    std::bind(&ZedCameraNitros::init, this));
+  // <---- Start a "one shot timer" to initialize the node and make `shared_from_this` available
+}
+
+void ZedCameraNitros::init() {
+  mInitTimer->cancel();
+
+  // Initialize parameters
+  initParameters();
+
+  // ----> Diagnostic initialization
+  mDiagUpdater.add(
+    "ZED Diagnostic", this,
+    &ZedCameraNitros::callback_updateDiagnostic);
+  std::string hw_id = std::string("Stereolabs camera: ") + mCameraName;
+  mDiagUpdater.setHardwareID(hw_id);
+  // <---- Diagnostic initialization
+
+  // ----> Start camera
+  if (!startCamera()) {
+    exit(EXIT_FAILURE);
+  }
+  // <---- Start camera
+
+  // Dynamic parameters callback
+  // mParamChangeCallbackHandle = add_on_set_parameters_callback(
+    // std::bind(&ZedCameraNitros::callback_setParameters, this, _1));
+}
+
+void ZedCameraNitros::callback_updateDiagnostic(
+  diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  DEBUG_COMM("*** Update Diagnostic ***");
+
+  if (mConnStatus != sl::ERROR_CODE::SUCCESS) {
+    stat.summary(
+      diagnostic_msgs::msg::DiagnosticStatus::ERROR,
+      sl::toString(mConnStatus).c_str());
+    return;
+  }
+
+  if (mGrabStatus == sl::ERROR_CODE::SUCCESS) {
+    double freq = 1. / mGrabPeriodMean_sec->getAvg();
+    double freq_perc = 100. * freq / mPubFrameRate;
+    stat.addf("Capture", "Mean Frequency: %.1f Hz (%.1f%%)", freq, freq_perc);
+
+    double frame_proc_sec = mElabPeriodMean_sec->getAvg();
+    // double frame_grab_period = 1. / mCamGrabFrameRate;
+    double frame_grab_period = 1. / mPubFrameRate;
+    stat.addf(
+      "Capture", "Tot. Processing Time: %.6f sec (Max. %.3f sec)",
+      frame_proc_sec, frame_grab_period);
+
+    if (frame_proc_sec > frame_grab_period) {
+      mSysOverloadCount++;
+    }
+
+    if (mSysOverloadCount >= 10) {
+      stat.summary(
+        diagnostic_msgs::msg::DiagnosticStatus::WARN,
+        "System overloaded. Consider reducing "
+        "'general.pub_frame_rate' or 'general.grab_resolution'");
+    } else {
+      mSysOverloadCount = 0;
+      stat.summary(
+        diagnostic_msgs::msg::DiagnosticStatus::OK,
+        "Camera grabbing");
+    }
+
+    stat.add("Input mode", "Live Camera");
+  } else if (mGrabStatus == sl::ERROR_CODE::LAST) {
+    stat.summary(
+      diagnostic_msgs::msg::DiagnosticStatus::OK,
+      "Camera initializing");
+  } else {
+    stat.summaryf(
+      diagnostic_msgs::msg::DiagnosticStatus::ERROR,
+      "Camera error: %s", sl::toString(mGrabStatus).c_str());
+  }
+
+  if (sl_tools::isZEDX(mCamRealModel)) {
+    stat.addf("Camera Temp.", "%.1f °C", mTempImu);
+
+    if (mTempImu > 70.f) {
+      stat.summary(
+        diagnostic_msgs::msg::DiagnosticStatus::WARN,
+        "High Camera temperature");
+    }
+  }
+} 
+
+void ZedCameraNitros::initParameters() {
+  // Init Debug parameters
+  getDebugParams();
+
+  // Init General parameters
+  getGeneralParams();
+
+  // Init Video parameters
+  getVideoParams();
+
+  // Init Sensors parameters
+  // SENSORS parameters
+  if (!sl_tools::isZED(mCamUserModel)) {
+    getSensorsParams();
+  }
+
+  // Init Advanced parameters
+  getAdvancedParams();
+}
+
+void ZedCameraNitros::getDebugParams() {
+  rclcpp::Parameter paramVal;
+
+  RCLCPP_INFO(get_logger(), "*** DEBUG parameters ***");
+
+  getParam("debug.sdk_verbose", mVerbose, mVerbose, " * SDK Verbose: ");
+
+  getParam("debug.debug_common", _debugCommon, _debugCommon);
+  RCLCPP_INFO(
+    get_logger(), " * Debug Common: %s",
+    _debugCommon ? "TRUE" : "FALSE");
+
+  getParam("debug.debug_sensors", _debugSensors, _debugSensors);
+  RCLCPP_INFO(
+    get_logger(), " * Debug sensors: %s",
+    _debugSensors ? "TRUE" : "FALSE");
+
+  getParam("debug.debug_camera_controls", _debugCamCtrl, _debugCamCtrl);
+  RCLCPP_INFO(
+    get_logger(), " * Debug Control settings: %s",
+    _debugCamCtrl ? "TRUE" : "FALSE");
+
+  getParam("debug.debug_advanced", _debugAdvanced, _debugAdvanced);
+  RCLCPP_INFO(
+    get_logger(), " * Debug Advanced: %s",
+    _debugAdvanced ? "TRUE" : "FALSE");
+  
+  getParam("debug.debug_video_depth", _debugVideoDepth, _debugVideoDepth);
+  RCLCPP_INFO(
+    get_logger(), " * Debug Video/Depth: %s",
+    _debugVideoDepth ? "TRUE" : "FALSE");
+
+  mDebugMode = _debugCommon || _debugCamCtrl || _debugSensors || _debugAdvanced || _debugVideoDepth;
+
+  if (mDebugMode) {
+    rcutils_ret_t res = rcutils_logging_set_logger_level(
+      get_logger().get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
+
+    if (res != RCUTILS_RET_OK) {
+      RCLCPP_INFO(get_logger(), "Error setting DEBUG level for logger");
+    } else {
+      RCLCPP_INFO(get_logger(), " + Debug Mode enabled +");
+    }
+  } else {
+    rcutils_ret_t res = rcutils_logging_set_logger_level(
+      get_logger().get_name(), RCUTILS_LOG_SEVERITY_INFO);
+
+    if (res != RCUTILS_RET_OK) {
+      RCLCPP_INFO(get_logger(), "Error setting INFO level for logger");
+    }
+  }
+
+  DEBUG_STREAM_COMM(
+    "[ROS2] Using RMW_IMPLEMENTATION "
+      << rmw_get_implementation_identifier());
+}
+
+void ZedCameraNitros::getVideoParams() {
+  rclcpp::Parameter paramVal;
+
+  RCLCPP_INFO(get_logger(), "*** VIDEO parameters ***");
+
+  rcl_interfaces::msg::ParameterDescriptor read_only_descriptor;
+  read_only_descriptor.read_only = true;
+
+  if (!sl_tools::isZEDX(mCamUserModel)) {
+    getParam(
+      "video.brightness", mCamBrightness, mCamBrightness,
+      " * [DYN] Brightness: ", true);
+    getParam(
+      "video.contrast", mCamContrast, mCamContrast,
+      " * [DYN] Contrast: ", true);
+    getParam("video.hue", mCamHue, mCamHue, " * [DYN] Hue: ", true);
+  }
+
+  getParam(
+    "video.saturation", mCamSaturation, mCamSaturation,
+    " * [DYN] Saturation: ", true);
+  getParam(
+    "video.sharpness", mCamSharpness, mCamSharpness,
+    " * [DYN] Sharpness: ", true);
+  getParam("video.gamma", mCamGamma, mCamGamma, " * [DYN] Gamma: ", true);
+  getParam(
+    "video.auto_exposure_gain", mCamAutoExpGain, mCamAutoExpGain, "",
+    true);
+  RCLCPP_INFO(
+    get_logger(), " * [DYN] Auto Exposure/Gain: %s",
+    mCamAutoExpGain ? "TRUE" : "FALSE");
+  if (mCamAutoExpGain) {
+    mTriggerAutoExpGain = true;
+  }
+  getParam(
+    "video.exposure", mCamExposure, mCamExposure,
+    " * [DYN] Exposure: ", true);
+  getParam("video.gain", mCamGain, mCamGain, " * [DYN] Gain: ", true);
+  getParam("video.auto_whitebalance", mCamAutoWB, mCamAutoWB, "", true);
+  RCLCPP_INFO(
+    get_logger(), " * [DYN] Auto White Balance: %s",
+    mCamAutoWB ? "TRUE" : "FALSE");
+  if (mCamAutoWB) {
+    mTriggerAutoWB = true;
+  }
+  int wb = 42;
+  getParam(
+    "video.whitebalance_temperature", wb, wb,
+    " * [DYN] White Balance Temperature: ", true);
+  mCamWBTemp = wb * 100;
+
+  if (sl_tools::isZEDX(mCamUserModel)) {
+    getParam(
+      "video.exposure_time", mGmslExpTime, mGmslExpTime,
+      " * [DYN] ZED X Exposure time: ", true);
+    getParam(
+      "video.auto_exposure_time_range_min", mGmslAutoExpTimeRangeMin,
+      mGmslAutoExpTimeRangeMin,
+      " * [DYN] ZED X Auto Exp. time range min: ", true);
+    getParam(
+      "video.auto_exposure_time_range_max", mGmslAutoExpTimeRangeMax,
+      mGmslAutoExpTimeRangeMax,
+      " * [DYN] ZED X Auto Exp. time range max: ", true);
+    if (mGmslAutoExpTimeRangeMax > mCamGrabFrameRate * 1000 ||
+      mGmslAutoExpTimeRangeMax > 30000)
+    {
+      mGmslAutoExpTimeRangeMax = std::max(mCamGrabFrameRate * 1000, 30000);
+      RCLCPP_WARN_STREAM(
+        get_logger(),
+        "The values of 'video.auto_exposure_time_range_max' is clamped to "
+        "max(30000,'general.grab_frame_rate'x1000): "
+          << mGmslAutoExpTimeRangeMax);
+    }
+    getParam(
+      "video.exposure_compensation", mGmslExposureComp,
+      mGmslExposureComp, " * [DYN] ZED X Exposure comp.: ", true);
+    getParam(
+      "video.analog_gain", mGmslAnalogGain, mGmslAnalogGain,
+      " * [DYN] ZED X Analog Gain: ", true);
+    getParam(
+      "video.auto_analog_gain_range_min", mGmslAnalogGainRangeMin,
+      mGmslAnalogGainRangeMin,
+      " * [DYN] ZED X Auto Analog Gain range min: ", true);
+    getParam(
+      "video.auto_analog_gain_range_max", mGmslAnalogGainRangeMax,
+      mGmslAnalogGainRangeMax,
+      " * [DYN] ZED X Auto Analog Gain range max: ", true);
+    getParam(
+      "video.digital_gain", mGmslDigitalGain, mGmslDigitalGain,
+      " * [DYN] ZED X Digital Gain: ", true);
+    getParam(
+      "video.auto_digital_gain_range_min", mGmslAutoDigitalGainRangeMin,
+      mGmslAutoDigitalGainRangeMin,
+      " * [DYN] ZED X Auto Digital Gain range min: ", true);
+    getParam(
+      "video.auto_digital_gain_range_max", mGmslAutoDigitalGainRangeMax,
+      mGmslAutoDigitalGainRangeMax,
+      " * [DYN] ZED X Auto Digital Gain range max: ", true);
+    getParam(
+      "video.denoising", mGmslDenoising, mGmslDenoising,
+      " * [DYN] ZED X Auto Digital Gain range max: ", true);
+  }
+}
+
+void ZedCameraNitros::getGeneralParams() {
+  rclcpp::Parameter paramVal;
+
+  RCLCPP_INFO(get_logger(), "*** GENERAL parameters ***");
+
+  std::string camera_model = "zed";
+  getParam("general.camera_model", camera_model, camera_model);
+  if (camera_model == "zed") {
+    mCamUserModel = sl::MODEL::ZED;
+  } else if (camera_model == "zedm") {
+    mCamUserModel = sl::MODEL::ZED_M;
+  } else if (camera_model == "zed2") {
+    mCamUserModel = sl::MODEL::ZED2;
+  } else if (camera_model == "zed2i") {
+    mCamUserModel = sl::MODEL::ZED2i;
+  } else if (camera_model == "zedx") {
+    mCamUserModel = sl::MODEL::ZED_X;
+    if (!IS_JETSON) {
+      RCLCPP_ERROR_STREAM(
+        get_logger(),
+        "Camera model " << sl::toString(mCamUserModel).c_str()
+                        << " is available only with NVIDIA Jetson devices.");
+      exit(EXIT_FAILURE);
+    }
+  } else if (camera_model == "zedxm") {
+    mCamUserModel = sl::MODEL::ZED_XM;
+    if (!IS_JETSON) {
+      RCLCPP_ERROR_STREAM(
+        get_logger(),
+        "Camera model " << sl::toString(mCamUserModel).c_str()
+                        << " is available only with NVIDIA Jetson devices.");
+      exit(EXIT_FAILURE);
+    }
+  } else if (camera_model == "virtual") {
+    mCamUserModel = sl::MODEL::VIRTUAL_ZED_X;
+
+    if (ZED_SDK_MAJOR_VERSION == 4 && ZED_SDK_MINOR_VERSION == 1 && ZED_SDK_PATCH_VERSION == 0) {
+      RCLCPP_ERROR_STREAM(
+        get_logger(),
+        "Camera model '" << sl::toString(mCamUserModel).c_str()
+                         << "' is available only with ZED SDK 4.1.1 or newer");
+      exit(EXIT_FAILURE);
+    }
+    
+    if (!IS_JETSON) {
+      RCLCPP_ERROR_STREAM(
+        get_logger(),
+        "Camera model " << sl::toString(mCamUserModel).c_str()
+                        << " is available only with NVIDIA Jetson devices.");
+      exit(EXIT_FAILURE);
+    }
+  } else {
+    RCLCPP_ERROR_STREAM(
+      get_logger(),
+      "Camera model not valid in parameter values: " << camera_model);
+  }
+  RCLCPP_INFO_STREAM(
+    get_logger(), " * Camera model: " << camera_model << " - "
+                                      << mCamUserModel);
+
+  getParam("general.camera_name", mCameraName, mCameraName, " * Camera name: ");
+  getParam(
+    "general.serial_number", mCamSerialNumber, mCamSerialNumber,
+    " * Camera SN: ");
+  getParam(
+    "general.camera_timeout_sec", mCamTimeoutSec, mCamTimeoutSec,
+    " * Camera timeout [sec]: ");
+  getParam(
+    "general.camera_max_reconnect", mMaxReconnectTemp, mMaxReconnectTemp,
+    " * Camera reconnection temptatives: ");
+  getParam(
+    "general.grab_frame_rate", mCamGrabFrameRate, mCamGrabFrameRate,
+    " * Camera framerate: ");
+
+  getParam("general.gpu_id", mGpuId, mGpuId, " * GPU ID: ");
+
+  // TODO(walter) ADD SVO SAVE COMPRESSION PARAMETERS
+
+  std::string resol = "AUTO";
+  getParam("general.grab_resolution", resol, resol);
+  if (resol == "AUTO") {
+    mCamResol = sl::RESOLUTION::AUTO;
+  } else if (sl_tools::isZEDX(mCamUserModel)) {
+    if (resol == "HD1200") {
+      mCamResol = sl::RESOLUTION::HD1200;
+    } else if (resol == "HD1080") {
+      mCamResol = sl::RESOLUTION::HD1080;
+    } else if (resol == "SVGA") {
+      mCamResol = sl::RESOLUTION::SVGA;
+    } else {
+      RCLCPP_WARN(
+        get_logger(),
+        "Not valid 'general.grab_resolution' value: '%s'. Using "
+        "'AUTO' setting.",
+        resol.c_str());
+      mCamResol = sl::RESOLUTION::AUTO;
+    }
+    RCLCPP_INFO_STREAM(
+      get_logger(), " * Camera resolution: "
+        << sl::toString(mCamResol).c_str());
+  } else {
+    if (resol == "HD2K") {
+      mCamResol = sl::RESOLUTION::HD2K;
+    } else if (resol == "HD1080") {
+      mCamResol = sl::RESOLUTION::HD1080;
+    } else if (resol == "HD720") {
+      mCamResol = sl::RESOLUTION::HD720;
+    } else if (resol == "VGA") {
+      mCamResol = sl::RESOLUTION::VGA;
+    } else {
+      RCLCPP_WARN(
+        get_logger(),
+        "Not valid 'general.grab_resolution' value: '%s'. Using "
+        "'AUTO' setting.",
+        resol.c_str());
+      mCamResol = sl::RESOLUTION::AUTO;
+    }
+    RCLCPP_INFO_STREAM(
+      get_logger(), " * Camera resolution: "
+        << sl::toString(mCamResol).c_str());
+  }
+
+  std::string out_resol = "MEDIUM";
+  getParam("general.pub_resolution", out_resol, out_resol);
+  if (out_resol == "NATIVE") {
+    mPubResolution = PubRes::NATIVE;
+  } else if (out_resol == "CUSTOM") {
+    mPubResolution = PubRes::CUSTOM;
+  } else {
+    RCLCPP_WARN(
+      get_logger(),
+      "Not valid 'general.pub_resolution' value: '%s'. Using default "
+      "setting instead.",
+      out_resol.c_str());
+    out_resol = "NATIVE";
+    mPubResolution = PubRes::NATIVE;
+  }
+  RCLCPP_INFO_STREAM(
+    get_logger(),
+    " * Publishing resolution: " << out_resol.c_str());
+
+  if (mPubResolution == PubRes::CUSTOM) {
+    getParam(
+      "general.pub_downscale_factor", mCustomDownscaleFactor,
+      mCustomDownscaleFactor, " * Publishing downscale factor: ");
+  } else {
+    mCustomDownscaleFactor = 1.0;
+  }
+
+  getParam(
+    "general.optional_opencv_calibration_file", mOpencvCalibFile,
+    mOpencvCalibFile, " * OpenCV custom calibration: ");
+
+  getParam("general.self_calib", mCameraSelfCalib, mCameraSelfCalib);
+  RCLCPP_INFO_STREAM(
+    get_logger(),
+    " * Camera self calibration: " << (mCameraSelfCalib ? "TRUE" : "FALSE"));
+  getParam("general.camera_flip", mCameraFlip, mCameraFlip);
+  RCLCPP_INFO_STREAM(
+    get_logger(),
+    " * Camera flip: " << (mCameraFlip ? "TRUE" : "FALSE"));
+
+  // Dynamic parameters
+
+  getParam("general.pub_frame_rate", mPubFrameRate, mPubFrameRate, "", false);
+  if (mPubFrameRate > mCamGrabFrameRate) {
+    RCLCPP_WARN(
+      get_logger(),
+      "'pub_frame_rate' cannot be bigger than 'grab_frame_rate'");
+    mPubFrameRate = mCamGrabFrameRate;
+  }
+  if (mPubFrameRate < 0.1) {
+    RCLCPP_WARN(
+      get_logger(),
+      "'pub_frame_rate' cannot be lower than 0.1 Hz or negative.");
+    mPubFrameRate = mCamGrabFrameRate;
+  }
+  RCLCPP_INFO_STREAM(
+    get_logger(),
+    " * [DYN] Publish framerate [Hz]:  " << mPubFrameRate);
+}
+
+void ZedCameraNitros::getSensorsParams() {
+  rclcpp::Parameter paramVal;
+
+  rcl_interfaces::msg::ParameterDescriptor read_only_descriptor;
+  read_only_descriptor.read_only = true;
+
+  RCLCPP_INFO(get_logger(), "*** SENSORS STACK parameters ***");
+  if (sl_tools::isZED(mCamUserModel)) {
+    RCLCPP_WARN(
+      get_logger(),
+      "!!! SENSORS parameters are not used with ZED !!!");
+    return;
+  }
+
+  getParam("sensors.publish_imu_tf", mPublishImuTF, mPublishImuTF);
+  RCLCPP_INFO_STREAM(
+    get_logger(), " * Broadcast IMU TF [not for ZED]: "
+      << (mPublishImuTF ? "TRUE" : "FALSE"));
+
+  getParam("sensors.sensors_image_sync", mSensCameraSync, mSensCameraSync);
+  RCLCPP_INFO_STREAM(
+    get_logger(), " * Sensors Camera Sync: "
+      << (mSensCameraSync ? "TRUE" : "FALSE"));
+
+  getParam("sensors.sensors_pub_rate", mSensPubRate, mSensPubRate);
+  if (mSensPubRate < mCamGrabFrameRate) {
+    mSensPubRate = mCamGrabFrameRate;
+  }
+  RCLCPP_INFO_STREAM(
+    get_logger(),
+    " * Sensors publishing rate: " << mSensPubRate << " Hz");
+}
+
+void ZedCameraNitros::getAdvancedParams() {
+  rclcpp::Parameter paramVal;
+
+  rcl_interfaces::msg::ParameterDescriptor read_only_descriptor;
+  read_only_descriptor.read_only = true;
+
+  RCLCPP_INFO(get_logger(), "*** Advanced parameters ***");
+
+  getParam(
+    "advanced.thread_sched_policy", mThreadSchedPolicy,
+    mThreadSchedPolicy, " * Thread sched. policy: ");
+
+  if (mThreadSchedPolicy == "SCHED_FIFO" || mThreadSchedPolicy == "SCHED_RR") {
+    if (!sl_tools::checkRoot()) {
+      RCLCPP_WARN_STREAM(
+        get_logger(),
+        "'sudo' permissions required to set "
+          << mThreadSchedPolicy
+          << " thread scheduling policy. Using Linux "
+          "default [SCHED_OTHER]");
+      mThreadSchedPolicy = "SCHED_OTHER";
+    } else {
+      getParam(
+        "advanced.thread_grab_priority", mThreadPrioGrab,
+        mThreadPrioGrab, " * Grab thread priority: ");
+      getParam(
+        "advanced.thread_sensor_priority", mThreadPrioSens,
+        mThreadPrioSens, " * Sensors thread priority: ");
+    }
+  }
+}
+
+bool ZedCameraNitros::startCamera() {
+  RCLCPP_INFO(get_logger(), "***** STARTING CAMERA *****");
+
+  // Create a ZED object
+  mZed = std::make_shared<sl::Camera>();
+
+  // ----> SDK version
+  RCLCPP_INFO(
+    get_logger(), "ZED SDK Version: %d.%d.%d - Build %s",
+    ZED_SDK_MAJOR_VERSION, ZED_SDK_MINOR_VERSION,
+    ZED_SDK_PATCH_VERSION, ZED_SDK_BUILD_ID);
+  // <---- SDK version
+  
+  // ----> TF2 Transform
+  mTfBuffer = std::make_unique<tf2_ros::Buffer>(get_clock());
+  mTfListener = std::make_unique<tf2_ros::TransformListener>(
+    *mTfBuffer);    // Start TF Listener thread
+  mTfBroadcaster = std::make_unique<tf2_ros::TransformBroadcaster>(this);
+  // <---- TF2 Transform
+
+  // ----> ZED configuration
+  RCLCPP_INFO(get_logger(), "*** CAMERA OPENING ***");
+
+  mInitParams.camera_fps = mCamGrabFrameRate;
+  mInitParams.grab_compute_capping_fps = static_cast<float>(mPubFrameRate);
+  mInitParams.camera_resolution = static_cast<sl::RESOLUTION>(mCamResol);
+
+  if (mCamSerialNumber > 0) {
+    mInitParams.input.setFromSerialNumber(mCamSerialNumber);
+  }
+
+  mInitParams.coordinate_system = ROS_COORDINATE_SYSTEM;
+  mInitParams.coordinate_units = ROS_MEAS_UNITS;
+  mInitParams.sdk_verbose = mVerbose;
+  mInitParams.sdk_gpu_id = mGpuId;
+  mInitParams.camera_image_flip = (mCameraFlip ? sl::FLIP_MODE::ON : sl::FLIP_MODE::OFF);
+
+  if (!mOpencvCalibFile.empty()) {
+    mInitParams.optional_opencv_calibration_file = mOpencvCalibFile.c_str();
+  }
+
+  mInitParams.camera_disable_self_calib = !mCameraSelfCalib;
+  mInitParams.enable_image_enhancement = true;
+  mInitParams.enable_right_side_measure = false;
+
+  mInitParams.async_grab_camera_recovery = 
+    true; // Camera recovery is handled asynchronously to provide information
+          // about this status
+
+  // NOTE: this is a temp fix to GMSL2 camera close issues
+  // TODO: check if this issue has been fixed in the SDK
+  if (sl_tools::isZEDX(mCamUserModel)) {
+    RCLCPP_INFO(get_logger(), "Disable async recovery for GMSL2 cameras");
+    mInitParams.async_grab_camera_recovery = false;
+  }
+  // <---- ZED configuration
+
+  // ----> Try to connect to a camera
+  sl_tools::StopWatch connectTimer(get_clock());
+
+  mThreadStop = false;
+  mGrabStatus = sl::ERROR_CODE::LAST;
+
+  while (1) {
+    rclcpp::sleep_for(500ms);
+
+    mConnStatus = mZed->open(mInitParams);
+
+    if (mConnStatus == sl::ERROR_CODE::SUCCESS) {
+      DEBUG_STREAM_COMM("Opening successfull");
+      break;
+    }
+
+    if (mConnStatus == sl::ERROR_CODE::INVALID_CALIBRATION_FILE) {
+      if (mOpencvCalibFile.empty()) {
+        RCLCPP_ERROR_STREAM(
+          get_logger(), "Calibration file error: "
+            << sl::toVerbose(mConnStatus));
+      } else {
+        RCLCPP_ERROR_STREAM(
+          get_logger(),
+          "If you are using a custom OpenCV calibration file, please check "
+          "the correctness of the path of the calibration file "
+          "in the parameter 'general.optional_opencv_calibration_file': '"
+            << mOpencvCalibFile << "'.");
+        RCLCPP_ERROR(
+          get_logger(),
+          "If the file exists, it may contain invalid information.");
+      }
+      return false;
+    }
+
+    RCLCPP_WARN(
+    get_logger(), "Error opening camera: %s",
+    sl::toString(mConnStatus).c_str());
+    if (mConnStatus == sl::ERROR_CODE::CAMERA_DETECTION_ISSUE &&
+      sl_tools::isZEDM(mCamUserModel))
+    {
+      RCLCPP_INFO(
+        get_logger(),
+        "Try to flip the USB3 Type-C connector and verify the USB3 "
+        "connection");
+    } else {
+      RCLCPP_INFO(get_logger(), "Please verify the camera connection");
+    }
+
+    if (!rclcpp::ok() || mThreadStop) {
+      RCLCPP_INFO(get_logger(), "ZED activation interrupted by user.");
+      return false;
+    }
+
+    if (connectTimer.toc() > mMaxReconnectTemp * mCamTimeoutSec) {
+      RCLCPP_ERROR(get_logger(), "Camera detection timeout");
+      return false;
+    }
+
+    rclcpp::sleep_for(std::chrono::seconds(mCamTimeoutSec));
+  }
+  // ----> Try to connect to a camera
+
+  // ----> Camera information
+  sl::CameraInformation camInfo = mZed->getCameraInformation();
+
+  float realFps = camInfo.camera_configuration.fps;
+  if (realFps != static_cast<float>(mCamGrabFrameRate)) {
+    RCLCPP_WARN_STREAM(
+      get_logger(),
+      "!!! `general.grab_frame_rate` value is not valid: '"
+        << mCamGrabFrameRate
+        << "'. Automatically replaced with '" << realFps
+        << "'. Please fix the parameter !!!");
+    mCamGrabFrameRate = realFps;
+  }
+
+  // CUdevice devid;
+  cuCtxGetDevice(&mGpuId);
+  RCLCPP_INFO_STREAM(get_logger(), "ZED SDK running on GPU #" << mGpuId);
+
+  // Camera model
+  mCamRealModel = camInfo.camera_model;
+
+  if (mCamRealModel == sl::MODEL::ZED) {
+    if (mCamUserModel != sl::MODEL::ZED) {
+      RCLCPP_WARN(
+        get_logger(),
+        "Camera model does not match user parameter. Please modify "
+        "the value of the parameter 'general.camera_model' to 'zed'");
+    }
+  } else if (mCamRealModel == sl::MODEL::ZED_M) {
+    if (mCamUserModel != sl::MODEL::ZED_M) {
+      RCLCPP_WARN(
+        get_logger(),
+        "Camera model does not match user parameter. Please modify "
+        "the value of the parameter 'general.camera_model' to 'zedm'");
+    }
+  } else if (mCamRealModel == sl::MODEL::ZED2) {
+    if (mCamUserModel != sl::MODEL::ZED2) {
+      RCLCPP_WARN(
+        get_logger(),
+        "Camera model does not match user parameter. Please modify "
+        "the value of the parameter 'general.camera_model' to 'zed2'");
+    }
+  } else if (mCamRealModel == sl::MODEL::ZED2i) {
+    if (mCamUserModel != sl::MODEL::ZED2i) {
+      RCLCPP_WARN(
+        get_logger(),
+        "Camera model does not match user parameter. Please modify "
+        "the value of the parameter 'general.camera_model' to 'zed2i'");
+    }
+  } else if (mCamRealModel == sl::MODEL::ZED_X) {
+    if (mCamUserModel != sl::MODEL::ZED_X) {
+      RCLCPP_WARN(
+        get_logger(),
+        "Camera model does not match user parameter. Please modify "
+        "the value of the parameter 'general.camera_model' to 'zedx'");
+    }
+  } else if (mCamRealModel == sl::MODEL::ZED_XM) {
+    if (mCamUserModel != sl::MODEL::ZED_XM) {
+      RCLCPP_WARN(
+        get_logger(),
+        "Camera model does not match user parameter. Please modify "
+        "the value of the parameter 'general.camera_model' to 'zedxm'");
+    }
+  } else if (mCamRealModel == sl::MODEL::VIRTUAL_ZED_X) {
+    if (mCamUserModel != sl::MODEL::VIRTUAL_ZED_X) {
+      RCLCPP_WARN(
+        get_logger(),
+        "Camera model does not match user parameter. Please modify "
+        "the value of the parameter 'general.camera_model' to 'zedxm'");
+    }
+  }
+
+  RCLCPP_INFO_STREAM(
+    get_logger(), " * Camera Model  -> "
+      << sl::toString(mCamRealModel).c_str());
+  mCamSerialNumber = camInfo.serial_number;
+  RCLCPP_INFO_STREAM(get_logger(), " * Serial Number -> " << mCamSerialNumber);
+
+  RCLCPP_INFO_STREAM(
+    get_logger(),
+    " * Focal Lenght -> "
+      << camInfo.camera_configuration.calibration_parameters
+      .left_cam.focal_length_metric
+      << " mm");
+
+  RCLCPP_INFO_STREAM(
+    get_logger(),
+    " * Input\t -> "
+      << sl::toString(mZed->getCameraInformation().input_type).c_str());
+  if (mSvoMode) {
+    RCLCPP_INFO(
+      get_logger(), " * SVO resolution\t-> %ldx%ld",
+      mZed->getCameraInformation().camera_configuration.resolution.width,
+      mZed->getCameraInformation().camera_configuration.resolution.height);
+    RCLCPP_INFO_STREAM(
+      get_logger(),
+      " * SVO framerate\t-> "
+        << (mZed->getCameraInformation().camera_configuration.fps));
+  }
+
+  // Firmwares
+  mCamFwVersion = camInfo.camera_configuration.firmware_version;
+
+  RCLCPP_INFO_STREAM(
+    get_logger(),
+    " * Camera FW Version  -> " << mCamFwVersion);
+  if (!sl_tools::isZED(mCamRealModel)) {
+    mSensFwVersion = camInfo.sensors_configuration.firmware_version;
+    RCLCPP_INFO_STREAM(
+      get_logger(),
+      " * Sensors FW Version -> " << mSensFwVersion);
+  }
+
+  // Camera/IMU transform
+  if (!sl_tools::isZED(mCamRealModel)) {
+    mSlCamImuTransf = camInfo.sensors_configuration.camera_imu_transform;
+
+    DEBUG_SENS("Camera-IMU Transform:\n%s", mSlCamImuTransf.getInfos().c_str());
+  }
+
+  mCamWidth = camInfo.camera_configuration.resolution.width;
+  mCamHeight = camInfo.camera_configuration.resolution.height;
+
+  RCLCPP_INFO_STREAM(
+    get_logger(), " * Camera grab frame size -> "
+      << mCamWidth << "x" << mCamHeight);
+
+  int pub_w, pub_h;
+  pub_w = static_cast<int>(std::round(mCamWidth / mCustomDownscaleFactor));
+  pub_h = static_cast<int>(std::round(mCamHeight / mCustomDownscaleFactor));
+
+  if (pub_w > mCamWidth || pub_h > mCamHeight) {
+    RCLCPP_WARN_STREAM(
+      get_logger(), "The publishing resolution ("
+        << pub_w << "x" << pub_h
+        << ") cannot be higher than the grabbing resolution ("
+        << mCamWidth << "x" << mCamHeight
+        << "). Using grab resolution for output messages.");
+    pub_w = mCamWidth;
+    pub_h = mCamHeight;
+  }
+
+  mMatResol = sl::Resolution(pub_w, pub_h);
+  RCLCPP_INFO_STREAM(
+    get_logger(), " * Publishing frame size  -> "
+      << mMatResol.width << "x"
+      << mMatResol.height);
+  // <---- Camera information
+
+  // ----> Check default camera settings
+  if (_debugCamCtrl) {
+    int value;
+    sl::ERROR_CODE err;
+    sl::VIDEO_SETTINGS setting;
+
+    if (!sl_tools::isZEDX(mCamRealModel)) {
+      setting = sl::VIDEO_SETTINGS::BRIGHTNESS;
+      err = mZed->getCameraSettings(setting, value);
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_ERROR_STREAM(
+          get_logger(), "Error Getting default param for "
+            << sl::toString(setting).c_str()
+            << ": "
+            << sl::toString(err).c_str());
+        exit(EXIT_FAILURE);
+      }
+      DEBUG_STREAM_CTRL(
+        "Default value for " << sl::toString(setting).c_str()
+                             << ": " << value);
+
+      setting = sl::VIDEO_SETTINGS::CONTRAST;
+      err = mZed->getCameraSettings(setting, value);
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_ERROR_STREAM(
+          get_logger(), "Error Getting default param for "
+            << sl::toString(setting).c_str()
+            << ": "
+            << sl::toString(err).c_str());
+        exit(EXIT_FAILURE);
+      }
+      DEBUG_STREAM_CTRL(
+        "Default value for " << sl::toString(setting).c_str()
+                             << ": " << value);
+
+      setting = sl::VIDEO_SETTINGS::HUE;
+      err = mZed->getCameraSettings(setting, value);
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_ERROR_STREAM(
+          get_logger(), "Error Getting default param for "
+            << sl::toString(setting).c_str()
+            << ": "
+            << sl::toString(err).c_str());
+        exit(EXIT_FAILURE);
+      }
+      DEBUG_STREAM_CTRL(
+        "Default value for " << sl::toString(setting).c_str()
+                             << ": " << value);
+    }
+
+    setting = sl::VIDEO_SETTINGS::SATURATION;
+    err = mZed->getCameraSettings(setting, value);
+    if (err != sl::ERROR_CODE::SUCCESS) {
+      RCLCPP_ERROR_STREAM(
+        get_logger(), "Error Getting default param for "
+          << sl::toString(setting).c_str()
+          << ": "
+          << sl::toString(err).c_str());
+      exit(EXIT_FAILURE);
+    }
+    DEBUG_STREAM_CTRL(
+      "Default value for " << sl::toString(setting).c_str()
+                           << ": " << value);
+
+    setting = sl::VIDEO_SETTINGS::SHARPNESS;
+    err = mZed->getCameraSettings(setting, value);
+    if (err != sl::ERROR_CODE::SUCCESS) {
+      RCLCPP_ERROR_STREAM(
+        get_logger(), "Error Getting default param for "
+          << sl::toString(setting).c_str()
+          << ": "
+          << sl::toString(err).c_str());
+      exit(EXIT_FAILURE);
+    }
+    DEBUG_STREAM_CTRL(
+      "Default value for " << sl::toString(setting).c_str()
+                           << ": " << value);
+
+    setting = sl::VIDEO_SETTINGS::GAMMA;
+    err = mZed->getCameraSettings(setting, value);
+    if (err != sl::ERROR_CODE::SUCCESS) {
+      RCLCPP_ERROR_STREAM(
+        get_logger(), "Error Getting default param for "
+          << sl::toString(setting).c_str()
+          << ": "
+          << sl::toString(err).c_str());
+      exit(EXIT_FAILURE);
+    }
+    DEBUG_STREAM_CTRL(
+      "Default value for " << sl::toString(setting).c_str()
+                           << ": " << value);
+
+    setting = sl::VIDEO_SETTINGS::AEC_AGC;
+    err = mZed->getCameraSettings(setting, value);
+    if (err != sl::ERROR_CODE::SUCCESS) {
+      RCLCPP_ERROR_STREAM(
+        get_logger(), "Error Getting default param for "
+          << sl::toString(setting).c_str()
+          << ": "
+          << sl::toString(err).c_str());
+      exit(EXIT_FAILURE);
+    }
+    DEBUG_STREAM_CTRL(
+      "Default value for " << sl::toString(setting).c_str()
+                           << ": " << value);
+
+    setting = sl::VIDEO_SETTINGS::EXPOSURE;
+    err = mZed->getCameraSettings(setting, value);
+    if (err != sl::ERROR_CODE::SUCCESS) {
+      RCLCPP_ERROR_STREAM(
+        get_logger(), "Error Getting default param for "
+          << sl::toString(setting).c_str()
+          << ": "
+          << sl::toString(err).c_str());
+      exit(EXIT_FAILURE);
+    }
+    DEBUG_STREAM_CTRL(
+      "Default value for " << sl::toString(setting).c_str()
+                           << ": " << value);
+
+    setting = sl::VIDEO_SETTINGS::GAIN;
+    err = mZed->getCameraSettings(setting, value);
+    if (err != sl::ERROR_CODE::SUCCESS) {
+      RCLCPP_ERROR_STREAM(
+        get_logger(), "Error Getting default param for "
+          << sl::toString(setting).c_str()
+          << ": "
+          << sl::toString(err).c_str());
+      exit(EXIT_FAILURE);
+    }
+    DEBUG_STREAM_CTRL(
+      "Default value for " << sl::toString(setting).c_str()
+                           << ": " << value);
+
+    setting = sl::VIDEO_SETTINGS::WHITEBALANCE_AUTO;
+    err = mZed->getCameraSettings(setting, value);
+    if (err != sl::ERROR_CODE::SUCCESS) {
+      RCLCPP_ERROR_STREAM(
+        get_logger(), "Error Getting default param for "
+          << sl::toString(setting).c_str()
+          << ": "
+          << sl::toString(err).c_str());
+      exit(EXIT_FAILURE);
+    }
+    DEBUG_STREAM_CTRL(
+      "Default value for " << sl::toString(setting).c_str()
+                           << ": " << value);
+
+    setting = sl::VIDEO_SETTINGS::WHITEBALANCE_TEMPERATURE;
+    err = mZed->getCameraSettings(setting, value);
+    if (err != sl::ERROR_CODE::SUCCESS) {
+      RCLCPP_ERROR_STREAM(
+        get_logger(), "Error Getting default param for "
+          << sl::toString(setting).c_str()
+          << ": "
+          << sl::toString(err).c_str());
+      exit(EXIT_FAILURE);
+    }
+    DEBUG_STREAM_CTRL(
+      "Default value for " << sl::toString(setting).c_str()
+                           << ": " << value);
+
+    if (sl_tools::isZEDX(mCamRealModel)) {
+      setting = sl::VIDEO_SETTINGS::EXPOSURE_TIME;
+      err = mZed->getCameraSettings(setting, value);
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_ERROR_STREAM(
+          get_logger(), "Error Getting default param for "
+            << sl::toString(setting).c_str()
+            << ": "
+            << sl::toString(err).c_str());
+        exit(EXIT_FAILURE);
+      }
+      DEBUG_STREAM_CTRL(
+        "[ZEDX] Default value for "
+          << sl::toString(setting).c_str() << ": " << value);
+
+      // TODO(Walter) Enable when fixed in the SDK
+      // setting = sl::VIDEO_SETTINGS::AUTO_EXPOSURE_TIME_RANGE;
+      // err = mZed->getCameraSettings(setting, value_min, value_max);
+      // if(err!=sl::ERROR_CODE::SUCCESS) {
+      //   RCLCPP_ERROR_STREAM( get_logger(), "Error Getting default param for
+      //   "
+      //   << sl::toString(setting).c_str() << ": " <<
+      //   sl::toString(err).c_str()); exit(EXIT_FAILURE);
+      // }
+      // DEBUG_STREAM_CTRL("[ZEDX] Default value for " <<
+      // sl::toString(setting).c_str() << ": [" << value_min << "," <<
+      // value_max
+      // << "]");
+
+      setting = sl::VIDEO_SETTINGS::EXPOSURE_COMPENSATION;
+      err = mZed->getCameraSettings(setting, value);
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_ERROR_STREAM(
+          get_logger(), "Error Getting default param for "
+            << sl::toString(setting).c_str()
+            << ": "
+            << sl::toString(err).c_str());
+        exit(EXIT_FAILURE);
+      }
+      DEBUG_STREAM_CTRL(
+        "[ZEDX] Default value for "
+          << sl::toString(setting).c_str() << ": " << value);
+  
+
+      setting = sl::VIDEO_SETTINGS::ANALOG_GAIN;
+      err = mZed->getCameraSettings(setting, value);
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_ERROR_STREAM(
+          get_logger(), "Error Getting default param for "
+            << sl::toString(setting).c_str()
+            << ": "
+            << sl::toString(err).c_str());
+        exit(EXIT_FAILURE);
+      }
+      DEBUG_STREAM_CTRL(
+        "[ZEDX] Default value for "
+          << sl::toString(setting).c_str() << ": " << value);
+
+      // TODO(Walter) Enable when fixed in the SDK
+      // setting = sl::VIDEO_SETTINGS::AUTO_ANALOG_GAIN_RANGE;
+      // err = mZed->getCameraSettings(setting, value_min, value_max);
+      // if(err!=sl::ERROR_CODE::SUCCESS) {
+      //   RCLCPP_ERROR_STREAM( get_logger(), "Error Getting default param for
+      //   "
+      //   << sl::toString(setting).c_str() << ": " <<
+      //   sl::toString(err).c_str()); exit(EXIT_FAILURE);
+      // }
+      // DEBUG_STREAM_CTRL("[ZEDX] Default value for " <<
+      // sl::toString(setting).c_str() << ": [" << value_min << "," <<
+      // value_max
+      // << "]");
+
+      setting = sl::VIDEO_SETTINGS::DIGITAL_GAIN;
+      err = mZed->getCameraSettings(setting, value);
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_ERROR_STREAM(
+          get_logger(), "Error Getting default param for "
+            << sl::toString(setting).c_str()
+            << ": "
+            << sl::toString(err).c_str());
+        exit(EXIT_FAILURE);
+      }
+      DEBUG_STREAM_CTRL(
+        "[ZEDX] Default value for "
+          << sl::toString(setting).c_str() << ": " << value);
+
+      // TODO(Walter) Enable when fixed in the SDK
+      // setting = sl::VIDEO_SETTINGS::AUTO_DIGITAL_GAIN_RANGE;
+      // err = mZed->getCameraSettings(setting, value_min, value_max);
+      // if(err!=sl::ERROR_CODE::SUCCESS) {
+      //   RCLCPP_ERROR_STREAM( get_logger(), "Error Getting default param for
+      //   "
+      //   << sl::toString(setting).c_str() << ": " <<
+      //   sl::toString(err).c_str()); exit(EXIT_FAILURE);
+      // }
+      // DEBUG_STREAM_CTRL("[ZEDX] Default value for " <<
+      // sl::toString(setting).c_str() << ": [" << value_min << "," <<
+      // value_max
+      // << "]");
+
+      setting = sl::VIDEO_SETTINGS::DENOISING;
+      err = mZed->getCameraSettings(setting, value);
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_ERROR_STREAM(
+          get_logger(), "Error Getting default param for "
+            << sl::toString(setting).c_str()
+            << ": "
+            << sl::toString(err).c_str());
+        exit(EXIT_FAILURE);
+      }
+      DEBUG_STREAM_CTRL(
+        "[ZEDX] Default value for "
+          << sl::toString(setting).c_str() << ": " << value);
+    }
+  }
+  // <----> Check default camera settings
+
+  // ----> Camera Info messages
+  mRgbCamInfoMsg = std::make_shared<sensor_msgs::msg::CameraInfo>();
+  mRgbCamInfoRawMsg = std::make_shared<sensor_msgs::msg::CameraInfo>();
+  mLeftCamInfoMsg = std::make_shared<sensor_msgs::msg::CameraInfo>();
+  mLeftCamInfoRawMsg = std::make_shared<sensor_msgs::msg::CameraInfo>();
+  mRightCamInfoMsg = std::make_shared<sensor_msgs::msg::CameraInfo>();
+  mRightCamInfoRawMsg = std::make_shared<sensor_msgs::msg::CameraInfo>();
+  mDepthCamInfoMsg = std::make_shared<sensor_msgs::msg::CameraInfo>();
+
+  setTFCoordFrameNames();  // Requires mZedRealCamModel available only after
+                           // camera opening
+
+  fillCamInfo(
+    mZed, mLeftCamInfoMsg, mRightCamInfoMsg, mLeftCamOptFrameId,
+    mRightCamOptFrameId);
+  fillCamInfo(
+    mZed, mLeftCamInfoRawMsg, mRightCamInfoRawMsg, mLeftCamOptFrameId,
+    mRightCamOptFrameId, true);
+  mRgbCamInfoMsg = mLeftCamInfoMsg;
+  mRgbCamInfoRawMsg = mLeftCamInfoRawMsg;
+  mDepthCamInfoMsg = mLeftCamInfoMsg;
+  // <---- Camera Info messages
+
+  // Init Nitros Publishers
+  initPublishers();
+
+  mZed->setCameraSettings(sl::VIDEO_SETTINGS::AEC_AGC, 0);
+  mZed->setCameraSettings(sl::VIDEO_SETTINGS::WHITEBALANCE_AUTO, 0);
+  // Force parameters with a dummy grab
+  mZed->grab();
+
+  // Initialialized timestamp to avoid wrong initial data
+  // ----> Timestamp
+  mFrameTimestamp = sl_tools::slTime2Ros(mZed->getTimestamp(sl::TIME_REFERENCE::IMAGE));
+  // <---- Timestamp
+
+  // ----> Initialize Diagnostic statistics
+  mElabPeriodMean_sec = std::make_unique<sl_tools::WinAvg>(mCamGrabFrameRate);
+  mGrabPeriodMean_sec = std::make_unique<sl_tools::WinAvg>(mCamGrabFrameRate);
+  // <---- Initialize Diagnostic statistics
+
+  // Init and start threads
+  initThreads();
+
+  return true;
+}
+
+void ZedCameraNitros::initThreads() {
+  // Start grab thread
+  mGrabThread = std::thread(&ZedCameraNitros::threadFunc_zedGrab, this);
+}
+
+void ZedCameraNitros::threadFunc_zedGrab() {
+  DEBUG_STREAM_COMM("Grab thread started");
+
+    // ----> Advanced thread settings
+  DEBUG_STREAM_ADV("Grab thread settings");
+  if (_debugAdvanced) {
+    int policy;
+    sched_param par;
+    if (pthread_getschedparam(pthread_self(), &policy, &par)) {
+      RCLCPP_WARN_STREAM(
+        get_logger(), " ! Failed to get thread policy! - "
+          << std::strerror(errno));
+    } else {
+      DEBUG_STREAM_ADV(
+        " * Default GRAB thread (#"
+          << pthread_self() << ") settings - Policy: "
+          << sl_tools::threadSched2Str(policy).c_str()
+          << " - Priority: " << par.sched_priority);
+    }
+  }
+
+  if (mThreadSchedPolicy == "SCHED_OTHER") {
+    sched_param par;
+    par.sched_priority = 0;
+    if (pthread_setschedparam(pthread_self(), SCHED_OTHER, &par)) {
+      RCLCPP_WARN_STREAM(
+        get_logger(), " ! Failed to set thread params! - "
+          << std::strerror(errno));
+    }
+  } else if (mThreadSchedPolicy == "SCHED_BATCH") {
+    sched_param par;
+    par.sched_priority = 0;
+    if (pthread_setschedparam(pthread_self(), SCHED_BATCH, &par)) {
+      RCLCPP_WARN_STREAM(
+        get_logger(), " ! Failed to set thread params! - "
+          << std::strerror(errno));
+    }
+  } else if (mThreadSchedPolicy == "SCHED_FIFO") {
+    sched_param par;
+    par.sched_priority = mThreadPrioGrab;
+    if (pthread_setschedparam(pthread_self(), SCHED_FIFO, &par)) {
+      RCLCPP_WARN_STREAM(
+        get_logger(), " ! Failed to set thread params! - "
+          << std::strerror(errno));
+    }
+  } else if (mThreadSchedPolicy == "SCHED_RR") {
+    sched_param par;
+    par.sched_priority = mThreadPrioGrab;
+    if (pthread_setschedparam(pthread_self(), SCHED_RR, &par)) {
+      RCLCPP_WARN_STREAM(
+        get_logger(), " ! Failed to set thread params! - "
+          << std::strerror(errno));
+    }
+  } else {
+    RCLCPP_WARN_STREAM(
+      get_logger(), " ! Failed to set thread params! - Policy not supported");
+  }
+
+  if (_debugAdvanced) {
+    int policy;
+    sched_param par;
+    if (pthread_getschedparam(pthread_self(), &policy, &par)) {
+      RCLCPP_WARN_STREAM(
+        get_logger(), " ! Failed to get thread policy! - "
+          << std::strerror(errno));
+    } else {
+      DEBUG_STREAM_ADV(
+        " * New GRAB thread (#"
+          << pthread_self() << ") settings - Policy: "
+          << sl_tools::threadSched2Str(policy).c_str()
+          << " - Priority: " << par.sched_priority);
+    }
+  }
+  // <---- Advanced thread settings
+
+  mFrameCount = 0;
+
+  // ----> Grab Runtime parameters
+  mRunParams.enable_depth = false;
+  mRunParams.measure3D_reference_frame = sl::REFERENCE_FRAME::CAMERA;
+  mRunParams.remove_saturated_areas = mRemoveSatAreas;
+  // <---- Grab Runtime parameters
+
+  while (1) {
+    try {
+      sl_tools::StopWatch grabElabTimer(get_clock());
+
+      // ----> Interruption check
+      if (!rclcpp::ok()) {
+        DEBUG_STREAM_COMM("Ctrl+C received: stopping grab thread");
+        break;
+      }
+
+      if (mThreadStop) {
+        DEBUG_STREAM_COMM("Grab thread stopped");
+        break;
+      }
+      // <---- Interruption check
+
+      applyVideoSettings();
+
+      // ----> Grab freq calculation
+      double elapsed_sec = mGrabFreqTimer.toc();
+      mGrabPeriodMean_sec->addValue(elapsed_sec);
+      mGrabFreqTimer.tic();
+      // <---- Grab freq calculation
+
+      // Start processing timer for diagnostic
+      grabElabTimer.tic();
+
+      // ZED Grab
+      mGrabStatus = mZed->grab(mRunParams);
+
+      // ----> Grab errors?
+      // Note: disconnection are automatically handled by the ZED SDK
+      if (mGrabStatus != sl::ERROR_CODE::SUCCESS) {
+        if (mGrabStatus == sl::ERROR_CODE::CAMERA_REBOOTING) {
+          RCLCPP_ERROR_STREAM(
+            get_logger(),
+            "Connection issue detected: "
+              << sl::toString(mGrabStatus).c_str());
+          rclcpp::sleep_for(1000ms);
+          continue;
+        } else if (mGrabStatus == sl::ERROR_CODE::CAMERA_NOT_INITIALIZED ||
+          mGrabStatus == sl::ERROR_CODE::FAILURE)
+        {
+          RCLCPP_ERROR_STREAM(
+            get_logger(),
+            "Camera issue detected: "
+              << sl::toString(mGrabStatus).c_str() << ". Trying to recover the connection...");
+          rclcpp::sleep_for(1000ms);
+          continue;
+        } else {
+          RCLCPP_ERROR_STREAM(
+            get_logger(),
+            "Critical camera error: " << sl::toString(mGrabStatus).c_str()
+                                      << ". NODE KILLED.");
+          mZed.reset();
+          exit(EXIT_FAILURE);
+        }
+      }
+
+      mFrameCount++;
+
+      // ----> Timestamp
+      mFrameTimestamp =
+            sl_tools::slTime2Ros(mZed->getTimestamp(sl::TIME_REFERENCE::IMAGE));
+      DEBUG_STREAM_COMM("Grab timestamp: " << mFrameTimestamp.nanoseconds() << " nsec");
+      // <---- Timestamp
+
+      // ----> Retrieve Image/Depth data if someone has subscribed to
+      // Retrieve data if there are subscriber to topics
+      DEBUG_STREAM_VD("Retrieving video/depth data");
+      retrieveVideoDepth();
+
+      rclcpp::Time pub_ts;
+      publishVideoDepth(pub_ts);
+      // <---- Retrieve Image/Depth data if someone has subscribed to
+
+      // Diagnostic statistics update
+      double mean_elab_sec = mElabPeriodMean_sec->addValue(grabElabTimer.toc());
+
+    } catch (...) {
+      rcutils_reset_error();
+      DEBUG_STREAM_COMM("threadFunc_zedGrab: Generic exception.");
+      continue;
+    }
+  }
+  DEBUG_STREAM_COMM("Grab thread finished");
+  // <---- Grab errors?
+}
+
+void ZedCameraNitros::applyVideoSettings() {
+  sl::ERROR_CODE err;
+  sl::VIDEO_SETTINGS setting;
+
+  if (mFrameCount % 10 == 0) {
+    std::lock_guard<std::mutex> lock(mDynParMutex);
+
+    if (mTriggerAutoExpGain) {
+      setting = sl::VIDEO_SETTINGS::AEC_AGC;
+      err = mZed->setCameraSettings(setting, (mCamAutoExpGain ? 1 : 0));
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_WARN_STREAM(
+          get_logger(), "Error setting AEC_AGC: "
+            << sl::toString(err).c_str());
+      } else {
+        mTriggerAutoExpGain = false;
+        DEBUG_STREAM_CTRL(
+          "New setting for " << sl::toString(setting).c_str()
+                             << ": "
+                             << (mCamAutoExpGain ? 1 : 0));
+      }
+    }
+
+    if (!mCamAutoExpGain) {
+      int value;
+      err = mZed->getCameraSettings(sl::VIDEO_SETTINGS::EXPOSURE, value);
+      if (err == sl::ERROR_CODE::SUCCESS && value != mCamExposure) {
+        mZed->setCameraSettings(sl::VIDEO_SETTINGS::EXPOSURE, mCamExposure);
+      }
+
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_WARN_STREAM(
+          get_logger(), "Error setting "
+            << sl::toString(setting).c_str()
+            << ": "
+            << sl::toString(err).c_str());
+      }
+
+      err = mZed->getCameraSettings(sl::VIDEO_SETTINGS::GAIN, value);
+      if (err == sl::ERROR_CODE::SUCCESS && value != mCamGain) {
+        err = mZed->setCameraSettings(sl::VIDEO_SETTINGS::GAIN, mCamGain);
+      }
+
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_WARN_STREAM(
+          get_logger(), "Error setting "
+            << sl::toString(setting).c_str()
+            << ": "
+            << sl::toString(err).c_str());
+      }
+    }
+
+    if (mTriggerAutoWB) {
+      setting = sl::VIDEO_SETTINGS::WHITEBALANCE_AUTO;
+      err = mZed->setCameraSettings(setting, (mCamAutoWB ? 1 : 0));
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_WARN_STREAM(
+          get_logger(), "Error setting "
+            << sl::toString(setting).c_str()
+            << ": "
+            << sl::toString(err).c_str());
+      } else {
+        mTriggerAutoWB = false;
+        DEBUG_STREAM_CTRL(
+          "New setting for " << sl::toString(setting).c_str()
+                             << ": " << (mCamAutoWB ? 1 : 0));
+      }
+    }
+
+    if (!mCamAutoWB) {
+      int value;
+      setting = sl::VIDEO_SETTINGS::WHITEBALANCE_TEMPERATURE;
+      err = mZed->getCameraSettings(setting, value);
+      if (err == sl::ERROR_CODE::SUCCESS && value != mCamWBTemp) {
+        err = mZed->setCameraSettings(setting, mCamWBTemp);
+      }
+
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_WARN_STREAM(
+          get_logger(), "Error setting "
+            << sl::toString(setting).c_str()
+            << ": "
+            << sl::toString(err).c_str());
+      }
+    }
+
+    // ----> BRIGHTNESS, CONTRAST, HUE controls not available for ZED X and
+    // ZED X Mini
+    if (!sl_tools::isZEDX(mCamRealModel)) {
+      int value;
+      setting = sl::VIDEO_SETTINGS::BRIGHTNESS;
+      err = mZed->getCameraSettings(setting, value);
+      if (err == sl::ERROR_CODE::SUCCESS && value != mCamBrightness) {
+        mZed->setCameraSettings(setting, mCamBrightness);
+      }
+
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_WARN_STREAM(
+          get_logger(), "Error setting "
+            << sl::toString(setting).c_str()
+            << ": "
+            << sl::toString(err).c_str());
+      }
+
+      setting = sl::VIDEO_SETTINGS::CONTRAST;
+      err = mZed->getCameraSettings(setting, value);
+      if (err == sl::ERROR_CODE::SUCCESS && value != mCamContrast) {
+        err = mZed->setCameraSettings(setting, mCamContrast);
+      }
+
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_WARN_STREAM(
+          get_logger(), "Error setting "
+            << sl::toString(setting).c_str()
+            << ": "
+            << sl::toString(err).c_str());
+      }
+
+      setting = sl::VIDEO_SETTINGS::HUE;
+      err = mZed->getCameraSettings(setting, value);
+      if (err == sl::ERROR_CODE::SUCCESS && value != mCamHue) {
+        mZed->setCameraSettings(setting, mCamHue);
+      }
+
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_WARN_STREAM(
+          get_logger(), "Error setting "
+            << sl::toString(setting).c_str()
+            << ": "
+            << sl::toString(err).c_str());
+      }
+    }
+    // <---- BRIGHTNESS, CONTRAST, HUE controls not available for ZED X and
+    // ZED X Mini
+
+    setting = sl::VIDEO_SETTINGS::SATURATION;
+    int value;
+    err = mZed->getCameraSettings(setting, value);
+    if (err == sl::ERROR_CODE::SUCCESS && value != mCamSaturation) {
+      mZed->setCameraSettings(setting, mCamSaturation);
+    }
+
+    if (err != sl::ERROR_CODE::SUCCESS) {
+      RCLCPP_WARN_STREAM(
+        get_logger(), "Error setting "
+          << sl::toString(setting).c_str()
+          << ": "
+          << sl::toString(err).c_str());
+    }
+
+    setting = sl::VIDEO_SETTINGS::SHARPNESS;
+    err = mZed->getCameraSettings(setting, value);
+    if (err == sl::ERROR_CODE::SUCCESS && value != mCamSharpness) {
+      mZed->setCameraSettings(setting, mCamSharpness);
+    }
+
+    if (err != sl::ERROR_CODE::SUCCESS) {
+      RCLCPP_WARN_STREAM(
+        get_logger(), "Error setting "
+          << sl::toString(setting).c_str()
+          << ": "
+          << sl::toString(err).c_str());
+    }
+
+    setting = sl::VIDEO_SETTINGS::GAMMA;
+    err = mZed->getCameraSettings(setting, value);
+    if (err == sl::ERROR_CODE::SUCCESS && value != mCamGamma) {
+      err = mZed->setCameraSettings(setting, mCamGamma);
+    }
+
+    if (err != sl::ERROR_CODE::SUCCESS) {
+      RCLCPP_WARN_STREAM(
+        get_logger(), "Error setting "
+          << sl::toString(setting).c_str()
+          << ": "
+          << sl::toString(err).c_str());
+    }
+
+    if (sl_tools::isZEDX(mCamRealModel)) {
+      if (!mCamAutoExpGain) {
+        setting = sl::VIDEO_SETTINGS::EXPOSURE_TIME;
+        err = mZed->getCameraSettings(setting, value);
+        if (err == sl::ERROR_CODE::SUCCESS && value != mGmslExpTime) {
+          err = mZed->setCameraSettings(setting, mGmslExpTime);
+          DEBUG_STREAM_CTRL(
+            "New setting for "
+              << sl::toString(setting).c_str() << ": "
+              << mGmslExpTime << " [Old " << value << "]");
+        }
+
+        if (err != sl::ERROR_CODE::SUCCESS) {
+          RCLCPP_WARN_STREAM(
+            get_logger(),
+            "Error setting " << sl::toString(setting).c_str()
+                             << ": "
+                             << sl::toString(err).c_str());
+        }
+      }
+
+      // TODO(Walter) Enable when fixed in the SDK
+      // err = mZed->getCameraSettings(
+      //   sl::VIDEO_SETTINGS::AUTO_EXPOSURE_TIME_RANGE, value_min,
+      //   value_max);
+      // if (err == sl::ERROR_CODE::SUCCESS &&
+      //   (value_min != mGmslAutoExpTimeRangeMin || value_max !=
+      //   mGmslAutoExpTimeRangeMax))
+      // {
+      //   err = mZed->setCameraSettings(
+      //     sl::VIDEO_SETTINGS::AUTO_EXPOSURE_TIME_RANGE,
+      //     mGmslAutoExpTimeRangeMin, mGmslAutoExpTimeRangeMax);
+      // } else if (err != sl::ERROR_CODE::SUCCESS) {
+      //   RCLCPP_WARN_STREAM(
+      //     get_logger(),
+      //     "Error setting AUTO_EXPOSURE_TIME_RANGE: " <<
+      //     sl::toString(err).c_str() );
+      // }
+      setting = sl::VIDEO_SETTINGS::EXPOSURE_COMPENSATION;
+      err = mZed->getCameraSettings(setting, value);
+      if (err == sl::ERROR_CODE::SUCCESS && value != mGmslExposureComp) {
+        err = mZed->setCameraSettings(setting, mGmslExposureComp);
+        DEBUG_STREAM_CTRL(
+          "New setting for " << sl::toString(setting).c_str()
+                              << ": " << mGmslExposureComp
+                              << " [Old " << value << "]");
+      }
+
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_WARN_STREAM(
+          get_logger(), "Error setting "
+            << sl::toString(setting).c_str()
+            << ": "
+            << sl::toString(err).c_str());
+      }
+
+      setting = sl::VIDEO_SETTINGS::ANALOG_GAIN;
+      if (!mCamAutoExpGain) {
+        err = mZed->getCameraSettings(setting, value);
+        if (err == sl::ERROR_CODE::SUCCESS && value != mGmslAnalogGain) {
+          err = mZed->setCameraSettings(setting, mGmslAnalogGain);
+          DEBUG_STREAM_CTRL(
+            "New setting for "
+              << sl::toString(setting).c_str() << ": "
+              << mGmslAnalogGain << " [Old " << value << "]");
+        }
+
+        if (err != sl::ERROR_CODE::SUCCESS) {
+          RCLCPP_WARN_STREAM(
+            get_logger(),
+            "Error setting " << sl::toString(setting).c_str()
+                             << ": "
+                             << sl::toString(err).c_str());
+        }
+
+        // TODO(Walter) Enable when fixed in the SDK
+        // err =
+        //   mZed->getCameraSettings(sl::VIDEO_SETTINGS::AUTO_ANALOG_GAIN_RANGE,
+        //   value_min, value_max);
+        // if (err == sl::ERROR_CODE::SUCCESS &&
+        //   (value_min != mGmslAnalogGainRangeMin || value_max !=
+        //   mGmslAnalogGainRangeMax))
+        // {
+        //   err = mZed->setCameraSettings(
+        //     sl::VIDEO_SETTINGS::AUTO_ANALOG_GAIN_RANGE,
+        //     mGmslAnalogGainRangeMin, mGmslAnalogGainRangeMax);
+        // } else if (err != sl::ERROR_CODE::SUCCESS) {
+        //   RCLCPP_WARN_STREAM(
+        //     get_logger(),
+        //     "Error setting AUTO_ANALOG_GAIN_RANGE: " <<
+        //     sl::toString(err).c_str() );
+        // }
+
+        setting = sl::VIDEO_SETTINGS::DIGITAL_GAIN;
+        err = mZed->getCameraSettings(setting, value);
+        if (err == sl::ERROR_CODE::SUCCESS && value != mGmslDigitalGain) {
+          err = mZed->setCameraSettings(setting, mGmslDigitalGain);
+          DEBUG_STREAM_CTRL(
+            "New setting for "
+              << sl::toString(setting).c_str() << ": "
+              << mGmslDigitalGain << " [Old " << value << "]");
+        }
+
+        if (err != sl::ERROR_CODE::SUCCESS) {
+          RCLCPP_WARN_STREAM(
+            get_logger(),
+            "Error setting " << sl::toString(setting).c_str()
+                             << ": "
+                             << sl::toString(err).c_str());
+        }
+      }
+
+      // TODO(Walter) Enable when fixed in the SDK
+      // err =
+      //   mZed->getCameraSettings(sl::VIDEO_SETTINGS::AUTO_DIGITAL_GAIN_RANGE,
+      //   value_min, value_max);
+      // if (err == sl::ERROR_CODE::SUCCESS &&
+      //   (value_min != mGmslAutoDigitalGainRangeMin || value_max !=
+      //   mGmslAutoDigitalGainRangeMax))
+      // {
+      //   err = mZed->setCameraSettings(
+      //     sl::VIDEO_SETTINGS::AUTO_DIGITAL_GAIN_RANGE,
+      //     mGmslAutoDigitalGainRangeMin, mGmslAnalogGainRangeMax);
+      // } else if (err != sl::ERROR_CODE::SUCCESS) {
+      //   RCLCPP_WARN_STREAM(
+      //     get_logger(),
+      //     "Error setting AUTO_DIGITAL_GAIN_RANGE: " <<
+      //     sl::toString(err).c_str() );
+      // }
+
+      setting = sl::VIDEO_SETTINGS::DENOISING;
+      err = mZed->getCameraSettings(setting, value);
+      if (err == sl::ERROR_CODE::SUCCESS && value != mGmslDenoising) {
+        err = mZed->setCameraSettings(setting, mGmslDenoising);
+        DEBUG_STREAM_CTRL(
+          "New setting for " << sl::toString(setting).c_str()
+                              << ": " << mGmslDenoising
+                              << " [Old " << value << "]");
+      }
+
+      if (err != sl::ERROR_CODE::SUCCESS) {
+        RCLCPP_WARN_STREAM(
+          get_logger(), "Error setting "
+            << sl::toString(setting).c_str()
+            << ": "
+            << sl::toString(err).c_str());
+      }
+    }
+  }
+}
+
+void ZedCameraNitros::setTFCoordFrameNames() {
+  // ----> Coordinate frames
+  mCameraFrameId = mCameraName + "_camera_center";
+  mLeftCamFrameId = mCameraName + "_left_camera_frame";
+  mLeftCamOptFrameId = mCameraName + "_left_camera_optical_frame";
+  mRightCamFrameId = mCameraName + "_right_camera_frame";
+  mRightCamOptFrameId = mCameraName + "_right_camera_optical_frame";
+
+  // Print TF Frames
+  RCLCPP_INFO_STREAM(get_logger(), " * Camera\t\t\t-> " << mCameraFrameId);
+  RCLCPP_INFO_STREAM(get_logger(), " * Left\t\t\t-> " << mLeftCamFrameId);
+  RCLCPP_INFO_STREAM(
+    get_logger(),
+    " * Left Optical\t\t-> " << mLeftCamOptFrameId);
+  RCLCPP_INFO_STREAM(get_logger(), " * Right\t\t\t-> " << mRightCamFrameId);
+  RCLCPP_INFO_STREAM(
+    get_logger(),
+    " * Right Optical\t\t-> " << mRightCamOptFrameId);
+  
+  if (!sl_tools::isZED(mCamRealModel)) {
+    if (sl_tools::isZED2OrZED2i(mCamUserModel)) {
+      RCLCPP_INFO_STREAM(
+        get_logger(),
+        " * Left Temperature\t-> " << mTempLeftFrameId);
+      RCLCPP_INFO_STREAM(
+        get_logger(),
+        " * Right Temperature\t-> " << mTempRightFrameId);
+    }
+  }
+  // <---- Coordinate frames
+}
+
+void ZedCameraNitros::fillCamInfo(
+  const std::shared_ptr<sl::Camera> zed,
+  const std::shared_ptr<sensor_msgs::msg::CameraInfo> & leftCamInfoMsg,
+  const std::shared_ptr<sensor_msgs::msg::CameraInfo> & rightCamInfoMsg,
+  const std::string & leftFrameId, const std::string & rightFrameId,
+  bool rawParam /*= false*/)
+{
+  sl::CalibrationParameters zedParam;
+
+  if (rawParam) {
+    zedParam = zed->getCameraInformation(mMatResol)
+      .camera_configuration.calibration_parameters_raw;
+  } else {
+    zedParam = zed->getCameraInformation(mMatResol)
+      .camera_configuration.calibration_parameters;
+  }
+
+  float baseline = zedParam.getCameraBaseline();
+
+  // ----> Distortion models
+  // ZED SDK params order: [ k1, k2, p1, p2, k3, k4, k5, k6, s1, s2, s3, s4]
+  // Radial (k1, k2, k3, k4, k5, k6), Tangential (p1,p2) and Prism (s1, s2, s3,
+  // s4) distortion. Prism not currently used.
+
+  // ROS2 order (OpenCV) -> k1,k2,p1,p2,k3,k4,k5,k6,s1,s2,s3,s4
+  switch (mCamRealModel) {
+    case sl::MODEL::ZED:  // PLUMB_BOB
+      leftCamInfoMsg->distortion_model =
+        sensor_msgs::distortion_models::PLUMB_BOB;
+      rightCamInfoMsg->distortion_model =
+        sensor_msgs::distortion_models::PLUMB_BOB;
+      leftCamInfoMsg->d.resize(5);
+      rightCamInfoMsg->d.resize(5);
+      leftCamInfoMsg->d[0] = zedParam.left_cam.disto[0];    // k1
+      leftCamInfoMsg->d[1] = zedParam.left_cam.disto[1];    // k2
+      leftCamInfoMsg->d[2] = zedParam.left_cam.disto[2];    // p1
+      leftCamInfoMsg->d[3] = zedParam.left_cam.disto[3];    // p2
+      leftCamInfoMsg->d[4] = zedParam.left_cam.disto[4];    // k3
+      rightCamInfoMsg->d[0] = zedParam.right_cam.disto[0];  // k1
+      rightCamInfoMsg->d[1] = zedParam.right_cam.disto[1];  // k2
+      rightCamInfoMsg->d[2] = zedParam.right_cam.disto[2];  // p1
+      rightCamInfoMsg->d[3] = zedParam.right_cam.disto[3];  // p2
+      rightCamInfoMsg->d[4] = zedParam.right_cam.disto[4];  // k3
+      break;
+
+    case sl::MODEL::ZED2:    // RATIONAL_POLYNOMIAL
+    case sl::MODEL::ZED2i:   // RATIONAL_POLYNOMIAL
+    case sl::MODEL::ZED_X:   // RATIONAL_POLYNOMIAL
+    case sl::MODEL::ZED_XM:  // RATIONAL_POLYNOMIAL
+    case sl::MODEL::VIRTUAL_ZED_X:  // RATIONAL_POLYNOMIAL
+      leftCamInfoMsg->distortion_model =
+        sensor_msgs::distortion_models::RATIONAL_POLYNOMIAL;
+      rightCamInfoMsg->distortion_model =
+        sensor_msgs::distortion_models::RATIONAL_POLYNOMIAL;
+      leftCamInfoMsg->d.resize(8);
+      rightCamInfoMsg->d.resize(8);
+      leftCamInfoMsg->d[0] = zedParam.left_cam.disto[0];    // k1
+      leftCamInfoMsg->d[1] = zedParam.left_cam.disto[1];    // k2
+      leftCamInfoMsg->d[2] = zedParam.left_cam.disto[2];    // p1
+      leftCamInfoMsg->d[3] = zedParam.left_cam.disto[3];    // p2
+      leftCamInfoMsg->d[4] = zedParam.left_cam.disto[4];    // k3
+      leftCamInfoMsg->d[5] = zedParam.left_cam.disto[5];    // k4
+      leftCamInfoMsg->d[6] = zedParam.left_cam.disto[6];    // k5
+      leftCamInfoMsg->d[7] = zedParam.left_cam.disto[7];    // k6
+      rightCamInfoMsg->d[0] = zedParam.right_cam.disto[0];  // k1
+      rightCamInfoMsg->d[1] = zedParam.right_cam.disto[1];  // k2
+      rightCamInfoMsg->d[2] = zedParam.right_cam.disto[2];  // p1
+      rightCamInfoMsg->d[3] = zedParam.right_cam.disto[3];  // p2
+      rightCamInfoMsg->d[4] = zedParam.right_cam.disto[4];  // k3
+      rightCamInfoMsg->d[5] = zedParam.right_cam.disto[5];  // k4
+      rightCamInfoMsg->d[6] = zedParam.right_cam.disto[6];  // k5
+      rightCamInfoMsg->d[7] = zedParam.right_cam.disto[7];  // k6
+      break;
+
+    case sl::MODEL::ZED_M:
+      if (zedParam.left_cam.disto[5] != 0 &&   // k4!=0
+        zedParam.right_cam.disto[2] == 0 &&    // p1==0
+        zedParam.right_cam.disto[3] == 0)      // p2==0
+      {
+        leftCamInfoMsg->distortion_model =
+          sensor_msgs::distortion_models::EQUIDISTANT;
+        rightCamInfoMsg->distortion_model =
+          sensor_msgs::distortion_models::EQUIDISTANT;
+
+        leftCamInfoMsg->d.resize(4);
+        rightCamInfoMsg->d.resize(4);
+        leftCamInfoMsg->d[0] = zedParam.left_cam.disto[0];    // k1
+        leftCamInfoMsg->d[1] = zedParam.left_cam.disto[1];    // k2
+        leftCamInfoMsg->d[2] = zedParam.left_cam.disto[4];    // k3
+        leftCamInfoMsg->d[3] = zedParam.left_cam.disto[5];    // k4
+        rightCamInfoMsg->d[0] = zedParam.right_cam.disto[0];  // k1
+        rightCamInfoMsg->d[1] = zedParam.right_cam.disto[1];  // k2
+        rightCamInfoMsg->d[2] = zedParam.right_cam.disto[4];  // k3
+        rightCamInfoMsg->d[3] = zedParam.right_cam.disto[5];  // k4
+      } else {
+        leftCamInfoMsg->distortion_model =
+          sensor_msgs::distortion_models::PLUMB_BOB;
+        rightCamInfoMsg->distortion_model =
+          sensor_msgs::distortion_models::PLUMB_BOB;
+        leftCamInfoMsg->d.resize(5);
+        rightCamInfoMsg->d.resize(5);
+        leftCamInfoMsg->d[0] = zedParam.left_cam.disto[0];    // k1
+        leftCamInfoMsg->d[1] = zedParam.left_cam.disto[1];    // k2
+        leftCamInfoMsg->d[2] = zedParam.left_cam.disto[2];    // p1
+        leftCamInfoMsg->d[3] = zedParam.left_cam.disto[3];    // p2
+        leftCamInfoMsg->d[4] = zedParam.left_cam.disto[4];    // k3
+        rightCamInfoMsg->d[0] = zedParam.right_cam.disto[0];  // k1
+        rightCamInfoMsg->d[1] = zedParam.right_cam.disto[1];  // k2
+        rightCamInfoMsg->d[2] = zedParam.right_cam.disto[2];  // p1
+        rightCamInfoMsg->d[3] = zedParam.right_cam.disto[3];  // p2
+        rightCamInfoMsg->d[4] = zedParam.right_cam.disto[4];  // k3
+      }
+  }
+
+  leftCamInfoMsg->k.fill(0.0);
+  rightCamInfoMsg->k.fill(0.0);
+  leftCamInfoMsg->k[0] = static_cast<double>(zedParam.left_cam.fx);
+  leftCamInfoMsg->k[2] = static_cast<double>(zedParam.left_cam.cx);
+  leftCamInfoMsg->k[4] = static_cast<double>(zedParam.left_cam.fy);
+  leftCamInfoMsg->k[5] = static_cast<double>(zedParam.left_cam.cy);
+  leftCamInfoMsg->k[8] = 1.0;
+  rightCamInfoMsg->k[0] = static_cast<double>(zedParam.right_cam.fx);
+  rightCamInfoMsg->k[2] = static_cast<double>(zedParam.right_cam.cx);
+  rightCamInfoMsg->k[4] = static_cast<double>(zedParam.right_cam.fy);
+  rightCamInfoMsg->k[5] = static_cast<double>(zedParam.right_cam.cy);
+  rightCamInfoMsg->k[8] = 1.0;
+  leftCamInfoMsg->r.fill(0.0);
+  rightCamInfoMsg->r.fill(0.0);
+
+  for (size_t i = 0; i < 3; i++) {
+    // identity
+    rightCamInfoMsg->r[i + i * 3] = 1;
+    leftCamInfoMsg->r[i + i * 3] = 1;
+  }
+
+  if (rawParam) {
+    // ROS frame (X forward, Z up, Y left)
+    for (int i = 0; i < 9; i++) {
+      rightCamInfoMsg->r[i] =
+        zedParam.stereo_transform.getRotationMatrix().r[i];
+    }
+  }
+
+  leftCamInfoMsg->p.fill(0.0);
+  rightCamInfoMsg->p.fill(0.0);
+  leftCamInfoMsg->p[0] = static_cast<double>(zedParam.left_cam.fx);
+  leftCamInfoMsg->p[2] = static_cast<double>(zedParam.left_cam.cx);
+  leftCamInfoMsg->p[5] = static_cast<double>(zedParam.left_cam.fy);
+  leftCamInfoMsg->p[6] = static_cast<double>(zedParam.left_cam.cy);
+  leftCamInfoMsg->p[10] = 1.0;
+  // http://docs.ros.org/api/sensor_msgs/html/msg/CameraInfo.html
+  rightCamInfoMsg->p[3] =
+    static_cast<double>(-1 * zedParam.left_cam.fx * baseline);
+  rightCamInfoMsg->p[0] = static_cast<double>(zedParam.right_cam.fx);
+  rightCamInfoMsg->p[2] = static_cast<double>(zedParam.right_cam.cx);
+  rightCamInfoMsg->p[5] = static_cast<double>(zedParam.right_cam.fy);
+  rightCamInfoMsg->p[6] = static_cast<double>(zedParam.right_cam.cy);
+  rightCamInfoMsg->p[10] = 1.0;
+  leftCamInfoMsg->width = rightCamInfoMsg->width =
+    static_cast<uint32_t>(mMatResol.width);
+  leftCamInfoMsg->height = rightCamInfoMsg->height =
+    static_cast<uint32_t>(mMatResol.height);
+  leftCamInfoMsg->header.frame_id = leftFrameId;
+  rightCamInfoMsg->header.frame_id = rightFrameId;
+}
+
+void ZedCameraNitros::initPublishers() {
+  RCLCPP_INFO(get_logger(), "*** PUBLISHED TOPICS ***");
+
+  std::string img_raw_nitros_topic = "nitros_image";
+  std::string nitros_rbg_left_topic = img_raw_nitros_topic + "/left_image_raw";
+  std::string nitros_rbg_right_topic = img_raw_nitros_topic + "/right_image_raw";
+  std::string nitros_rbg_left_topic_info = img_raw_nitros_topic + "/left_info";
+  std::string nitros_rbg_right_topic_info = img_raw_nitros_topic + "/right_info";
+
+  // Nitros Image topics
+  mNitrosPubLeftRgb = std::make_shared<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosImage>>(
+    this,
+    nitros_rbg_left_topic,
+    nvidia::isaac_ros::nitros::nitros_image_bgra8_t::supported_type_name,
+    nvidia::isaac_ros::nitros::NitrosDiagnosticsConfig(),
+    output_qos_nitros
+  );
+
+  RCLCPP_INFO_STREAM(
+    get_logger(),
+    "Advertised Nitros on toipc: " << nitros_rbg_left_topic
+  );
+
+  mNitrosPubRightRgb = std::make_shared<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosImage>>(
+    this,
+    nitros_rbg_right_topic,
+    nvidia::isaac_ros::nitros::nitros_image_bgra8_t::supported_type_name,
+    nvidia::isaac_ros::nitros::NitrosDiagnosticsConfig(),
+    output_qos_nitros
+  );
+
+  RCLCPP_INFO_STREAM(
+    get_logger(),
+    "Advertised Nitros on toipc: " << nitros_rbg_right_topic
+  );
+
+  mNitrosPubRightRgbInfo = std::make_shared<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosCameraInfo>>(
+    this,
+    nitros_rbg_right_topic_info,
+    nvidia::isaac_ros::nitros::nitros_camera_info_t::supported_type_name,
+    nvidia::isaac_ros::nitros::NitrosDiagnosticsConfig(),
+    output_qos_nitros
+  );
+
+  RCLCPP_INFO_STREAM(
+    get_logger(),
+    "Advertised Nitros on toipc: " << nitros_rbg_right_topic_info
+  );
+
+  mNitrosPubLeftRgbInfo = std::make_shared<nvidia::isaac_ros::nitros::ManagedNitrosPublisher<nvidia::isaac_ros::nitros::NitrosCameraInfo>>(
+    this,
+    nitros_rbg_left_topic_info,
+    nvidia::isaac_ros::nitros::nitros_camera_info_t::supported_type_name,
+    nvidia::isaac_ros::nitros::NitrosDiagnosticsConfig(),
+    output_qos_nitros
+  );
+
+  RCLCPP_INFO_STREAM(
+    get_logger(),
+    "Advertised Nitros on toipc: " << nitros_rbg_left_topic_info
+  );
+}
+
+ZedCameraNitros::~ZedCameraNitros()
+{
+  RCLCPP_INFO(get_logger(), "ZED Camera component stopped");
+}
+}
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(stereolabs::ZedCameraNitros)

--- a/zed_components/src/zed_camera/src/zed_camera_one_component.cpp
+++ b/zed_components/src/zed_camera/src/zed_camera_one_component.cpp
@@ -2601,7 +2601,7 @@ void ZedCameraOne::retrieveImages()
   if (_colorSubCount > 0) {
     retrieved |=
       (sl::ERROR_CODE::SUCCESS ==
-      _zed->retrieveImage(_matColor, sl::VIEW::LEFT, sl::MEM::CPU, _matResol));
+      _zed->retrieveImage(_matColor, sl::VIEW::LEFT, sl::MEM::GPU, _matResol));
     _sdkGrabTS = _matColor.timestamp;
     DEBUG_STREAM_VD(
       "Color image " << _matResol.width << "x" << _matResol.height << " retrieved - timestamp: " << _sdkGrabTS.getNanoseconds() <<

--- a/zed_wrapper/config/common_stereo.yaml
+++ b/zed_wrapper/config/common_stereo.yaml
@@ -23,7 +23,7 @@
             serial_number: 0 # usually overwritten by launch file
             pub_resolution: "NATIVE" # The resolution used for output. 'NATIVE' to use the same `general.grab_resolution` - `CUSTOM` to apply the `general.pub_downscale_factor` downscale factory to reduce bandwidth in transmission
             pub_downscale_factor: 2.0 # rescale factor used to rescale image before publishing when 'pub_resolution' is 'CUSTOM'
-            pub_frame_rate: 15.0 # frequency of publishing of visual images and depth images
+            pub_frame_rate: 30.0 # frequency of publishing of visual images and depth images
             gpu_id: -1
             optional_opencv_calibration_file: "" # Optional path where the ZED SDK can find a file containing the calibration information of the camera computed by OpenCV. Read the ZED SDK documentation for more information: https://www.stereolabs.com/docs/api/structsl_1_1InitParameters.html#a9eab2753374ef3baec1d31960859ba19
 
@@ -41,7 +41,7 @@
             whitebalance_temperature: 42 # [DYNAMIC] - [28,65] x100 - works only if `auto_whitebalance` is false
 
         sensors:
-            publish_imu_tf: true # [usually overwritten by launch file] enable/disable the IMU TF broadcasting
+            publish_imu_tf: false # [usually overwritten by launch file] enable/disable the IMU TF broadcasting
             sensors_image_sync: false # Synchronize Sensors messages with latest published video/depth message
             sensors_pub_rate: 200. # frequency of publishing of sensors data. MAX: 400. - MIN: grab rate
 
@@ -53,11 +53,11 @@
             #manual_polygon: "[[0.25,0.33],[0.75,0.33],[0.75,0.5],[0.5,0.75],[0.25,0.5]]" # A polygon defining the ROI where the ZED SDK perform the processing ignoring the rest. Coordinates must be normalized to '1.0' to be resolution independent.
             #manual_polygon: '[[0.25,0.25],[0.75,0.25],[0.75,0.75],[0.25,0.75]]' # A polygon defining the ROI where the ZED SDK perform the processing ignoring the rest. Coordinates must be normalized to '1.0' to be resolution independent.
             #manual_polygon: '[[0.5,0.25],[0.75,0.5],[0.5,0.75],[0.25,0.5]]' # A polygon defining the ROI where the ZED SDK perform the processing ignoring the rest. Coordinates must be normalized to '1.0' to be resolution independent.
-            apply_to_depth: true # Apply ROI to depth processing
-            apply_to_positional_tracking: true # Apply ROI to positional tracking processing
-            apply_to_object_detection: true # Apply ROI to object detection processing
-            apply_to_body_tracking: true # Apply ROI to body tracking processing
-            apply_to_spatial_mapping: true # Apply ROI to spatial mapping processing
+            apply_to_depth: false # Apply ROI to depth processing
+            apply_to_positional_tracking: false # Apply ROI to positional tracking processing
+            apply_to_object_detection: false # Apply ROI to object detection processing
+            apply_to_body_tracking: false # Apply ROI to body tracking processing
+            apply_to_spatial_mapping: false # Apply ROI to spatial mapping processing
 
         depth: # Only stereo cameras
             depth_mode: "NEURAL" # Matches the ZED SDK setting: 'NONE', 'PERFORMANCE', 'QUALITY', 'ULTRA', 'NEURAL', 'NEURAL_PLUS' - Note: if 'NONE' all the modules that requires depth extraction are disabled by default (Pos. Tracking, Obj. Detection, Mapping, ...)
@@ -69,7 +69,7 @@
             remove_saturated_areas: true # [DYNAMIC]
 
         pos_tracking: # Only stereo cameras
-            pos_tracking_enabled: true # True to enable positional tracking from start
+            pos_tracking_enabled: false # True to enable positional tracking from start
             pos_tracking_mode: "GEN_2" # Matches the ZED SDK setting: 'GEN_1', 'GEN_2'
             imu_fusion: true # enable/disable IMU fusion. When set to false, only the optical odometry will be used.
             publish_tf: true # [usually overwritten by launch file] publish `odom -> camera_link` TF

--- a/zed_wrapper/launch/zed_camera.launch.py
+++ b/zed_wrapper/launch/zed_camera.launch.py
@@ -316,7 +316,7 @@ def generate_launch_description():
                 description='The path to an additional parameters file to override the defaults'),
             DeclareLaunchArgument(
                 'svo_path',
-                default_value=TextSubstitution(text='live'),
+                default_value=TextSubstitution(text=''),
                 description='Path to an input SVO file.'),
             DeclareLaunchArgument(
                 'enable_gnss',


### PR DESCRIPTION
#### Description

This PR adds Nitros Image and Camera Info publishers. It is currently adding nitros publishers besides default ROS image transport publishers. later shortly, a new ZEDX camera component will be implemented which will contain only Nitros Image Publishers

#### Acceptance criteria

- [x] add nitros publisher for image and camera info 
- [ ] test and build on Jetson
- [ ] Ensure performance